### PR TITLE
Remove `Client(..., on_heartbeat=...)`, add `Client.is_alive()`, improve FastStream health check

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -25,7 +25,7 @@ test *args:
 run-artemis:
     #!/bin/bash
     trap 'echo; docker compose down --remove-orphans' EXIT
-    docker compose run --service-ports artemis
+    docker compose run --service-ports activemq-artemis
 
 run-consumer:
     uv run examples/consumer.py

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ async with stompman.Client(
         stompman.ConnectionParameters(host="172.0.0.1", port=61616, login="user2", passcode="passcode2"),
     ],
 
-    # Handlers:
-    on_error_frame=lambda error_frame: print(error_frame.body),
-    on_heartbeat=lambda: print("Server sent a heartbeat"),  # also can be async
 
     # SSL — can be either `None` (default), `True`, or `ssl.SSLContext'
     ssl=None,
+
+    # Error frame handler:
+    on_error_frame=lambda error_frame: print(error_frame.body),
 
     # Optional parameters with sensible defaults:
     heartbeat=stompman.Heartbeat(will_send_interval_ms=1000, want_to_receive_interval_ms=1000),
@@ -40,6 +40,7 @@ async with stompman.Client(
     disconnect_confirmation_timeout=2,
     read_timeout=2,
     write_retry_attempts=3,
+    check_server_alive_interval_factor=3,
 ) as client:
     ...
 ```
@@ -131,6 +132,7 @@ stompman takes care of cleaning up resources automatically. When you leave the c
 - If multiple servers were provided, stompman will attempt to connect to each one simultaneously and will use the first that succeeds. If all servers fail to connect, an `stompman.FailedAllConnectAttemptsError` will be raised. In normal situation it doesn't need to be handled: tune retry and timeout parameters in `stompman.Client()` to your needs.
 
 - When connection is lost, stompman will attempt to handle it automatically. `stompman.FailedAllConnectAttemptsError` will be raised if all connection attempts fail. `stompman.FailedAllWriteAttemptsError` will be raised if connection succeeds but sending a frame or heartbeat lead to losing connection.
+- To implement health checks, use `stompman.Client.is_alive()` — it will return `True` if everything is OK and `False` if server is not responding.
 
 ### ...and caveats
 

--- a/packages/faststream-stomp/faststream_stomp/broker.py
+++ b/packages/faststream-stomp/faststream_stomp/broker.py
@@ -114,7 +114,7 @@ class StompBroker(StompRegistrator, BrokerUsecase[stompman.MessageFrame, stompma
                 if cancel_scope.cancel_called:
                     return False
 
-                if self._connection._connection_manager._active_connection_state:  # noqa: SLF001
+                if self._connection.is_alive():
                     return True
 
                 await anyio.sleep(sleep_time)  # pragma: no cover

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -1,6 +1,4 @@
 import asyncio
-import inspect
-import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
@@ -123,18 +121,10 @@ class Client:
         server_heartbeat_interval_seconds = server_heartbeat_interval_ms / 1000
         while True:
             await asyncio.sleep(server_heartbeat_interval_seconds * self.check_server_alive_interval_factor)
-            last_read_time_ms = (
-                self._connection_manager._active_connection_state
-                and self._connection_manager._active_connection_state.connection.last_read_time_ms
-            )
-            if not last_read_time_ms:
-                print("No last_Read_time_ms")
+            if not self._connection_manager._active_connection_state:
                 continue
-            if (t := time.time() - last_read_time_ms) > server_heartbeat_interval_seconds:
-                print("reset time", t)
+            if not self._connection_manager._active_connection_state.is_alive():
                 self._connection_manager._active_connection_state = None
-            else:
-                print("no reset")
 
     async def _listen_to_frames(self) -> None:
         async with asyncio.TaskGroup() as task_group:

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -171,3 +171,8 @@ class Client:
         )
         await subscription._subscribe()  # noqa: SLF001
         return subscription
+
+    def is_alive(self) -> bool:
+        return (
+            self._connection_manager._active_connection_state or False  # noqa: SLF001
+        ) and self._connection_manager._active_connection_state.is_alive()  # noqa: SLF001

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import time
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
@@ -52,7 +53,8 @@ class Client:
     _active_subscriptions: ActiveSubscriptions = field(default_factory=dict, init=False)
     _active_transactions: set[Transaction] = field(default_factory=set, init=False)
     _exit_stack: AsyncExitStack = field(default_factory=AsyncExitStack, init=False)
-    _heartbeat_task: asyncio.Task[None] = field(init=False)
+    _send_heartbeat_task: asyncio.Task[None] = field(init=False)
+    _check_server_heartbeat_task: asyncio.Task[None] = field(init=False)
     _listen_task: asyncio.Task[None] = field(init=False)
     _task_group: asyncio.TaskGroup = field(init=False)
     _on_heartbeat_is_async: bool = field(init=False)
@@ -68,7 +70,7 @@ class Client:
                 disconnect_confirmation_timeout=self.disconnect_confirmation_timeout,
                 active_subscriptions=self._active_subscriptions,
                 active_transactions=self._active_transactions,
-                set_heartbeat_interval=self._restart_heartbeat_task,
+                set_heartbeat_interval=self._restart_heartbeat_tasks,
             ),
             connection_class=self.connection_class,
             connect_retry_attempts=self.connect_retry_attempts,
@@ -83,7 +85,8 @@ class Client:
 
     async def __aenter__(self) -> Self:
         self._task_group = await self._exit_stack.enter_async_context(asyncio.TaskGroup())
-        self._heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
+        self._send_heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
+        self._check_server_heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
         await self._exit_stack.enter_async_context(self._connection_manager)
         self._listen_task = self._task_group.create_task(self._listen_to_frames())
         return self
@@ -96,18 +99,42 @@ class Client:
                 await asyncio.Future()
         finally:
             self._listen_task.cancel()
-            self._heartbeat_task.cancel()
-            await asyncio.wait([self._listen_task, self._heartbeat_task])
+            self._send_heartbeat_task.cancel()
+            self._check_server_heartbeat_task.cancel()
+            await asyncio.wait([self._listen_task, self._send_heartbeat_task, self._check_server_heartbeat_task])
             await self._exit_stack.aclose()
 
-    def _restart_heartbeat_task(self, interval: float) -> None:
-        self._heartbeat_task.cancel()
-        self._heartbeat_task = self._task_group.create_task(self._send_heartbeats_forever(interval))
+    def _restart_heartbeat_tasks(self, server_heartbeat: Heartbeat) -> None:
+        self._send_heartbeat_task.cancel()
+        self._check_server_heartbeat_task.cancel()
+        self._send_heartbeat_task = self._task_group.create_task(
+            self._send_heartbeats_forever(server_heartbeat.want_to_receive_interval_ms)
+        )
+        self._check_server_heartbeat_task = self._task_group.create_task(
+            self._monitor_server_aliveness(server_heartbeat.will_send_interval_ms)
+        )
 
-    async def _send_heartbeats_forever(self, interval: float) -> None:
+    async def _send_heartbeats_forever(self, client_heartbeat_interval_ms: int) -> None:
         while True:
             await self._connection_manager.write_heartbeat_reconnecting()
-            await asyncio.sleep(interval)
+            await asyncio.sleep(client_heartbeat_interval_ms / 1000)
+
+    async def _monitor_server_aliveness(self, server_heartbeat_interval_ms: int) -> None:
+        server_heartbeat_interval_seconds = server_heartbeat_interval_ms / 1000
+        while True:
+            await asyncio.sleep(server_heartbeat_interval_seconds * self.check_server_alive_interval_factor)
+            last_read_time_ms = (
+                self._connection_manager._active_connection_state
+                and self._connection_manager._active_connection_state.connection.last_read_time_ms
+            )
+            if not last_read_time_ms:
+                print("No last_Read_time_ms")
+                continue
+            if (t:=time.time() - last_read_time_ms) > server_heartbeat_interval_seconds:
+                print("reset time", t)
+                self._connection_manager._active_connection_state = None
+            else:
+                print("no reset")
 
     async def _listen_to_frames(self) -> None:
         async with asyncio.TaskGroup() as task_group:

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -79,6 +79,7 @@ class Client:
             read_timeout=self.read_timeout,
             read_max_chunk_size=self.read_max_chunk_size,
             write_retry_attempts=self.write_retry_attempts,
+            check_server_alive_interval_factor=self.check_server_alive_interval_factor,
             ssl=self.ssl,
         )
         self._on_heartbeat_is_async = inspect.iscoroutinefunction(self.on_heartbeat) if self.on_heartbeat else False
@@ -130,7 +131,7 @@ class Client:
             if not last_read_time_ms:
                 print("No last_Read_time_ms")
                 continue
-            if (t:=time.time() - last_read_time_ms) > server_heartbeat_interval_seconds:
+            if (t := time.time() - last_read_time_ms) > server_heartbeat_interval_seconds:
                 print("reset time", t)
                 self._connection_manager._active_connection_state = None
             else:

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -86,6 +86,7 @@ class Client:
 
     async def __aenter__(self) -> Self:
         self._task_group = await self._exit_stack.enter_async_context(asyncio.TaskGroup())
+        # TODO: move this tasks to lifespan
         self._send_heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
         self._check_server_heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
         await self._exit_stack.enter_async_context(self._connection_manager)

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -109,6 +109,7 @@ class Client:
     def _restart_heartbeat_tasks(self, server_heartbeat: Heartbeat) -> None:
         self._send_heartbeat_task.cancel()
         self._check_server_heartbeat_task.cancel()
+        print(server_heartbeat)
         self._send_heartbeat_task = self._task_group.create_task(
             self._send_heartbeats_forever(server_heartbeat.want_to_receive_interval_ms)
         )

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -43,6 +43,8 @@ class Client:
     write_retry_attempts: int = 3
     connection_confirmation_timeout: int = 2
     disconnect_confirmation_timeout: int = 2
+    check_server_alive_interval_factor: int = 3
+    """Client will check if server alive `server heartbeat interval` times `interval factor`"""
 
     connection_class: type[AbstractConnection] = Connection
 

--- a/packages/stompman/stompman/connection.py
+++ b/packages/stompman/stompman/connection.py
@@ -14,7 +14,7 @@ from stompman.serde import NEWLINE, FrameParser, dump_frame
 
 @dataclass(kw_only=True)
 class AbstractConnection(Protocol):
-    last_read_time_ms: float | None = field(init=False, default=None)
+    last_read_time: float | None = field(init=False, default=None)
 
     @classmethod
     async def connect(
@@ -103,7 +103,7 @@ class Connection(AbstractConnection):
                 raw_frames = await asyncio.wait_for(
                     self._read_non_empty_bytes(self.read_max_chunk_size), timeout=self.read_timeout
                 )
-            self.last_read_time_ms = time.time()
+            self.last_read_time = time.time()
 
             for frame in cast("Iterator[AnyServerFrame]", parser.parse_frames_from_chunk(raw_frames)):
                 yield frame

--- a/packages/stompman/stompman/connection.py
+++ b/packages/stompman/stompman/connection.py
@@ -14,7 +14,7 @@ from stompman.serde import NEWLINE, FrameParser, dump_frame
 
 @dataclass(kw_only=True)
 class AbstractConnection(Protocol):
-    last_read_time: float | None = field(init=False, default=None)
+    last_read_time_ms: float | None = field(init=False, default=None)
 
     @classmethod
     async def connect(
@@ -103,7 +103,7 @@ class Connection(AbstractConnection):
                 raw_frames = await asyncio.wait_for(
                     self._read_non_empty_bytes(self.read_max_chunk_size), timeout=self.read_timeout
                 )
-            self.last_read_time = time.time()
+            self.last_read_time_ms = time.time()
 
             for frame in cast("Iterator[AnyServerFrame]", parser.parse_frames_from_chunk(raw_frames)):
                 yield frame

--- a/packages/stompman/stompman/connection_lifespan.py
+++ b/packages/stompman/stompman/connection_lifespan.py
@@ -110,5 +110,9 @@ def _make_receipt_id() -> str:
 
 class ConnectionLifespanFactory(Protocol):
     def __call__(
-        self, *, connection: AbstractConnection, connection_parameters: ConnectionParameters
+        self,
+        *,
+        connection: AbstractConnection,
+        connection_parameters: ConnectionParameters,
+        set_heartbeat_interval: Callable[[Heartbeat], Any],
     ) -> AbstractConnectionLifespan: ...

--- a/packages/stompman/stompman/connection_lifespan.py
+++ b/packages/stompman/stompman/connection_lifespan.py
@@ -1,7 +1,8 @@
 import asyncio
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 from uuid import uuid4
 
 from stompman.config import ConnectionParameters, Heartbeat
@@ -24,8 +25,6 @@ from stompman.transaction import ActiveTransactions, commit_pending_transactions
 class AbstractConnectionLifespan(Protocol):
     async def enter(self) -> StompProtocolConnectionIssue | None: ...
     async def exit(self) -> None: ...
-
-
 
 
 @dataclass(kw_only=True, slots=True)

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -129,13 +129,13 @@ class ConnectionManager:
         self._active_connection_state = None
 
     def is_alive(self) -> bool:
-        if not self._connection_manager._active_connection_state:
+        if not self._active_connection_state:
             return False
-        if not (last_read_time_ms := self._connection_manager._active_connection_state.connection.last_read_time_ms):
+        if not (last_read_time_ms := self._active_connection_state.connection.last_read_time_ms):
             return True
-        if (time.time() - last_read_time_ms) > server_heartbeat_interval_seconds:
-            ...
-        return None
+        return self._active_connection_state.server_heartbeat.will_send_interval_ms / 1000 > (
+            time.time() - last_read_time_ms
+        )
 
     async def write_heartbeat_reconnecting(self) -> None:
         for _ in range(self.write_retry_attempts):

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -49,15 +49,26 @@ class ConnectionManager:
     check_server_alive_interval_factor: int
 
     _active_connection_state: ActiveConnectionState | None = field(default=None, init=False)
-    _reconnect_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _reconnect_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
+    _task_group: asyncio.TaskGroup = field(init=False, default_factory=asyncio.TaskGroup)
+    _send_heartbeat_task: asyncio.Task[None] = field(init=False, repr=False)
+    _check_server_heartbeat_task: asyncio.Task[None] = field(init=False, repr=False)
 
     async def __aenter__(self) -> Self:
+        await self._task_group.__aenter__()
+        self._send_heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
+        self._check_server_heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
         self._active_connection_state = await self._get_active_connection_state()
         return self
 
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None
     ) -> None:
+        self._send_heartbeat_task.cancel()
+        self._check_server_heartbeat_task.cancel()
+        await asyncio.wait([self._send_heartbeat_task, self._check_server_heartbeat_task])
+        await self._task_group.__aexit__(exc_type, exc_value, traceback)
+
         if not self._active_connection_state:
             return
         try:
@@ -65,6 +76,31 @@ class ConnectionManager:
         except ConnectionLostError:
             return
         await self._active_connection_state.connection.close()
+
+    def _restart_heartbeat_tasks(self, server_heartbeat: Heartbeat) -> None:
+        self._send_heartbeat_task.cancel()
+        self._check_server_heartbeat_task.cancel()
+        self._send_heartbeat_task = self._task_group.create_task(
+            self._send_heartbeats_forever(server_heartbeat.want_to_receive_interval_ms)
+        )
+        self._check_server_heartbeat_task = self._task_group.create_task(
+            self._check_server_heartbeat_forever(server_heartbeat.will_send_interval_ms)
+        )
+
+    async def _send_heartbeats_forever(self, send_heartbeat_interval_ms: int) -> None:
+        send_heartbeat_interval_seconds = send_heartbeat_interval_ms / 1000
+        while True:
+            await self.write_heartbeat_reconnecting()
+            await asyncio.sleep(send_heartbeat_interval_seconds)
+
+    async def _check_server_heartbeat_forever(self, receive_heartbeat_interval_ms: int) -> None:
+        receive_heartbeat_interval_seconds = receive_heartbeat_interval_ms / 1000
+        while True:
+            await asyncio.sleep(receive_heartbeat_interval_seconds * self.check_server_alive_interval_factor)
+            if not self._active_connection_state:
+                continue
+            if not self._active_connection_state.is_alive():
+                self._active_connection_state = None
 
     async def _create_connection_to_one_server(
         self, server: ConnectionParameters
@@ -94,7 +130,11 @@ class ConnectionManager:
         if not (connection_and_server := await self._create_connection_to_any_server()):
             return AllServersUnavailable(servers=self.servers, timeout=self.connect_timeout)
         connection, connection_parameters = connection_and_server
-        lifespan = self.lifespan_factory(connection=connection, connection_parameters=connection_parameters)
+        lifespan = self.lifespan_factory(
+            connection=connection,
+            connection_parameters=connection_parameters,
+            set_heartbeat_interval=self._restart_heartbeat_tasks,
+        )
 
         try:
             connection_result = await lifespan.enter()

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Literal, Self
 
 from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection
-from stompman.connection_lifespan import EstablishedConnectionResult
 from stompman.errors import (
     AllServersUnavailable,
     AnyConnectionIssue,
@@ -85,6 +84,8 @@ class ConnectionManager:
         return None
 
     async def _connect_to_any_server(self) -> ActiveConnectionState | AnyConnectionIssue:
+        from stompman.connection_lifespan import EstablishedConnectionResult  # noqa: PLC0415
+
         if not (connection_and_server := await self._create_connection_to_any_server()):
             return AllServersUnavailable(servers=self.servers, timeout=self.connect_timeout)
         connection, connection_parameters = connection_and_server

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -29,9 +29,9 @@ class ActiveConnectionState:
     server_heartbeat: Heartbeat
 
     def is_alive(self) -> bool:
-        if not (last_read_time_ms := self.connection.last_read_time_ms):
+        if not (last_read_time := self.connection.last_read_time):
             return True
-        return (self.server_heartbeat.will_send_interval_ms / 1000) > (time.time() - last_read_time_ms)
+        return (self.server_heartbeat.will_send_interval_ms / 1000) > (time.time() - last_read_time)
 
 
 @dataclass(kw_only=True, slots=True)

--- a/packages/stompman/test_stompman/conftest.py
+++ b/packages/stompman/test_stompman/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import stompman
 from polyfactory.factories.dataclass_factory import DataclassFactory
 from stompman.connection import AbstractConnection
-from stompman.connection_lifespan import AbstractConnectionLifespan
+from stompman.connection_lifespan import AbstractConnectionLifespan, EstablishedConnectionResult
 from stompman.connection_manager import ConnectionManager
 
 
@@ -59,7 +59,9 @@ class NoopLifespan(AbstractConnectionLifespan):
     connection: AbstractConnection
     connection_parameters: stompman.ConnectionParameters
 
-    async def enter(self) -> stompman.StompProtocolConnectionIssue | None: ...
+    async def enter(self) -> EstablishedConnectionResult | stompman.StompProtocolConnectionIssue:
+        return EstablishedConnectionResult(server_heartbeat=stompman.Heartbeat(1000, 1000))
+
     async def exit(self) -> None: ...
 
 
@@ -76,6 +78,7 @@ class EnrichedConnectionManager(ConnectionManager):
     read_max_chunk_size: int = 5
     write_retry_attempts: int = 3
     ssl: Literal[True] | SSLContext | None = None
+    check_server_alive_interval_factor: int = 3
 
 
 DataclassType = TypeVar("DataclassType")

--- a/packages/stompman/test_stompman/conftest.py
+++ b/packages/stompman/test_stompman/conftest.py
@@ -125,7 +125,9 @@ CONNECT_FRAME = stompman.ConnectFrame(
         "passcode": "passcode",
     },
 )
-CONNECTED_FRAME = stompman.ConnectedFrame(headers={"version": stompman.Client.PROTOCOL_VERSION, "heart-beat": "1,1"})
+CONNECTED_FRAME = stompman.ConnectedFrame(
+    headers={"version": stompman.Client.PROTOCOL_VERSION, "heart-beat": "1000,1000"}
+)
 
 
 @pytest.fixture(autouse=True)

--- a/packages/stompman/test_stompman/conftest.py
+++ b/packages/stompman/test_stompman/conftest.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
 from ssl import SSLContext
 from typing import Any, Literal, Self, TypeVar
@@ -7,6 +7,7 @@ from typing import Any, Literal, Self, TypeVar
 import pytest
 import stompman
 from polyfactory.factories.dataclass_factory import DataclassFactory
+from stompman.config import Heartbeat
 from stompman.connection import AbstractConnection
 from stompman.connection_lifespan import AbstractConnectionLifespan, EstablishedConnectionResult
 from stompman.connection_manager import ConnectionManager
@@ -58,6 +59,7 @@ class EnrichedClient(stompman.Client):
 class NoopLifespan(AbstractConnectionLifespan):
     connection: AbstractConnection
     connection_parameters: stompman.ConnectionParameters
+    set_heartbeat_interval: Callable[[Heartbeat], Any]
 
     async def enter(self) -> EstablishedConnectionResult | stompman.StompProtocolConnectionIssue:
         return EstablishedConnectionResult(server_heartbeat=stompman.Heartbeat(1000, 1000))

--- a/packages/stompman/test_stompman/test_aliveness.py
+++ b/packages/stompman/test_stompman/test_aliveness.py
@@ -1,0 +1,21 @@
+import time
+
+import pytest
+from stompman import Client, ConnectedFrame, ReceiptFrame
+
+from test_stompman.conftest import EnrichedClient, build_dataclass, create_spying_connection
+
+pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("mock_sleep")]
+
+
+@pytest.mark.parametrize("is_alive", [True, False])
+async def test_connection_alive(is_alive: bool) -> None:  # noqa: FBT001
+    connection_class, _ = create_spying_connection(
+        [ConnectedFrame(headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1000,1000"})],
+        [],
+        [build_dataclass(ReceiptFrame)],
+    )
+    client = await EnrichedClient(connection_class=connection_class).__aenter__()
+    assert client._connection_manager._active_connection_state
+    client._connection_manager._active_connection_state.connection.last_read_time = time.time() - 1 + is_alive
+    assert client.is_alive() == is_alive

--- a/packages/stompman/test_stompman/test_connection_lifespan.py
+++ b/packages/stompman/test_stompman/test_connection_lifespan.py
@@ -152,7 +152,7 @@ async def test_client_heartbeats_ok(monkeypatch: pytest.MonkeyPatch) -> None:
         await real_sleep(0)
         await real_sleep(0)
 
-    assert sleep_calls == [0, 1, 1]
+    assert sleep_calls == [0, 0, 1, 3, 1, 3]
     assert write_heartbeat_mock.mock_calls == [mock.call(), mock.call(), mock.call()]
 
 

--- a/packages/stompman/test_stompman/test_connection_lifespan.py
+++ b/packages/stompman/test_stompman/test_connection_lifespan.py
@@ -147,11 +147,9 @@ async def test_client_heartbeats_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
     async with EnrichedClient(connection_class=connection_class):
         await real_sleep(0)
-        await real_sleep(0)
-        await real_sleep(0)
 
-    assert sleep_calls == [0, 0, 1, 3, 1, 3]
-    assert write_heartbeat_mock.mock_calls == [mock.call(), mock.call(), mock.call()]
+    assert sleep_calls == [0, 0, 1, 3, 1, 3, 1, 3]
+    assert write_heartbeat_mock.mock_calls == [mock.call(), mock.call(), mock.call(), mock.call()]
 
 
 def test_make_receipt_id(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/stompman/test_stompman/test_connection_lifespan.py
+++ b/packages/stompman/test_stompman/test_connection_lifespan.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections.abc import AsyncGenerator, Coroutine
-from functools import partial
 from typing import Any
 from unittest import mock
 
@@ -17,7 +16,6 @@ from stompman import (
     DisconnectFrame,
     ErrorFrame,
     FailedAllConnectAttemptsError,
-    HeartbeatFrame,
     ReceiptFrame,
     UnsupportedProtocolVersion,
 )
@@ -154,58 +152,6 @@ async def test_client_heartbeats_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert sleep_calls == [0, 0, 1, 3, 1, 3]
     assert write_heartbeat_mock.mock_calls == [mock.call(), mock.call(), mock.call()]
-
-
-async def test_client_on_heartbeat_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    real_sleep = asyncio.sleep
-    monkeypatch.setattr("asyncio.sleep", partial(asyncio.sleep, 0))
-    connection_class, _ = create_spying_connection(
-        *get_read_frames_with_lifespan(
-            [build_dataclass(HeartbeatFrame), build_dataclass(HeartbeatFrame), build_dataclass(HeartbeatFrame)]
-        )
-    )
-
-    async with EnrichedClient(connection_class=connection_class, on_heartbeat=None):
-        await real_sleep(0)
-        await real_sleep(0)
-        await real_sleep(0)
-
-
-async def test_client_on_heartbeat_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    real_sleep = asyncio.sleep
-    monkeypatch.setattr("asyncio.sleep", partial(asyncio.sleep, 0))
-    connection_class, _ = create_spying_connection(
-        *get_read_frames_with_lifespan(
-            [build_dataclass(HeartbeatFrame), build_dataclass(HeartbeatFrame), build_dataclass(HeartbeatFrame)]
-        )
-    )
-    on_heartbeat_mock = mock.Mock()
-
-    async with EnrichedClient(connection_class=connection_class, on_heartbeat=on_heartbeat_mock):
-        await real_sleep(0)
-        await real_sleep(0)
-        await real_sleep(0)
-
-    assert on_heartbeat_mock.mock_calls == [mock.call(), mock.call(), mock.call()]
-
-
-async def test_client_on_heartbeat_async(monkeypatch: pytest.MonkeyPatch) -> None:
-    real_sleep = asyncio.sleep
-    monkeypatch.setattr("asyncio.sleep", partial(asyncio.sleep, 0))
-    connection_class, _ = create_spying_connection(
-        *get_read_frames_with_lifespan(
-            [build_dataclass(HeartbeatFrame), build_dataclass(HeartbeatFrame), build_dataclass(HeartbeatFrame)]
-        )
-    )
-    on_heartbeat_mock = mock.AsyncMock()
-
-    async with EnrichedClient(connection_class=connection_class, on_heartbeat=on_heartbeat_mock):
-        await real_sleep(0)
-        await real_sleep(0)
-        await real_sleep(0)
-
-    assert on_heartbeat_mock.await_count == 3  # noqa: PLR2004
-    assert on_heartbeat_mock.mock_calls == [mock.call.__bool__(), mock.call(), mock.call(), mock.call()]
 
 
 def test_make_receipt_id(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -14,11 +14,13 @@ from stompman import (
     ErrorFrame,
     FailedAllConnectAttemptsError,
     FailedAllWriteAttemptsError,
+    Heartbeat,
     MessageFrame,
 )
+from stompman.connection_lifespan import EstablishedConnectionResult
 from stompman.connection_manager import ActiveConnectionState
 
-from test_stompman.conftest import BaseMockConnection, EnrichedConnectionManager, NoopLifespan, build_dataclass
+from test_stompman.conftest import BaseMockConnection, EnrichedConnectionManager, build_dataclass
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("mock_sleep")]
 
@@ -110,8 +112,7 @@ async def test_connect_to_any_server_ok() -> None:
     )
     active_connection_state = await manager._create_connection_to_any_server()
     assert active_connection_state
-    assert isinstance(active_connection_state.lifespan, NoopLifespan)
-    assert active_connection_state.lifespan.connection_parameters == successful_server
+    assert active_connection_state[1] == successful_server
 
 
 async def test_connect_to_any_server_fails() -> None:
@@ -169,7 +170,8 @@ async def test_get_active_connection_state_fails_to_connect() -> None:
 
 
 async def test_get_active_connection_state_ok_concurrent() -> None:
-    enter = mock.AsyncMock(return_value=None)
+    server_heartbeat = build_dataclass(Heartbeat)
+    enter = mock.AsyncMock(return_value=EstablishedConnectionResult(server_heartbeat=server_heartbeat))
     lifespan_factory = mock.Mock(return_value=mock.Mock(enter=enter))
     manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=BaseMockConnection)
 
@@ -185,7 +187,9 @@ async def test_get_active_connection_state_ok_concurrent() -> None:
         == second_state
         == third_state
         == fourth_state
-        == ActiveConnectionState(connection=BaseMockConnection(), lifespan=lifespan_factory.return_value)
+        == ActiveConnectionState(
+            connection=BaseMockConnection(), lifespan=lifespan_factory.return_value, server_heartbeat=server_heartbeat
+        )
     )
     assert first_state is second_state is third_state is fourth_state
 

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -202,7 +202,9 @@ async def test_get_active_connection_state_ok_concurrent() -> None:
     assert first_state is second_state is third_state is fourth_state
 
     enter.assert_called_once_with()
-    lifespan_factory.assert_called_once_with(connection=BaseMockConnection(), connection_parameters=manager.servers[0])
+    lifespan_factory.assert_called_once_with(
+        connection=BaseMockConnection(), connection_parameters=manager.servers[0], set_heartbeat_interval=mock.ANY
+    )
 
 
 async def test_connection_manager_context_connection_lost() -> None:

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from collections.abc import AsyncGenerator, AsyncIterable
 from ssl import SSLContext
 from typing import Literal, Self
@@ -8,7 +7,6 @@ from unittest import mock
 import pytest
 from stompman import (
     AnyServerFrame,
-    Client,
     ConnectedFrame,
     ConnectFrame,
     ConnectionLostError,
@@ -18,7 +16,6 @@ from stompman import (
     FailedAllWriteAttemptsError,
     Heartbeat,
     MessageFrame,
-    ReceiptFrame,
 )
 from stompman.connection_lifespan import EstablishedConnectionResult
 from stompman.connection_manager import ActiveConnectionState
@@ -27,7 +24,6 @@ from test_stompman.conftest import (
     BaseMockConnection,
     EnrichedConnectionManager,
     build_dataclass,
-    create_spying_connection,
 )
 
 pytestmark = [pytest.mark.anyio, pytest.mark.usefixtures("mock_sleep")]

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -355,16 +355,3 @@ async def test_maybe_write_frame_connection_now_lost() -> None:
 async def test_maybe_write_frame_ok() -> None:
     async with EnrichedConnectionManager(connection_class=BaseMockConnection) as manager:
         assert await manager.maybe_write_frame(build_dataclass(ConnectFrame))
-
-
-@pytest.mark.parametrize("is_alive", [True, False])
-async def test_connection_alive(is_alive: bool) -> None:  # noqa: FBT001
-    connection_class, _ = create_spying_connection(
-        [ConnectedFrame(headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1000,1000"})],
-        [],
-        [build_dataclass(ReceiptFrame)],
-    )
-    connection_manager = await EnrichedConnectionManager(connection_class=connection_class).__aenter__()
-    assert connection_manager._active_connection_state
-    connection_manager._active_connection_state.connection.last_read_time = time.time() - 1 + is_alive
-    assert connection_manager._active_connection_state.is_alive() == is_alive

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -140,8 +140,16 @@ async def test_get_active_connection_state_lifespan_flaky_ok() -> None:
 
     assert enter.mock_calls == [mock.call(), mock.call()]
     assert lifespan_factory.mock_calls == [
-        mock.call(connection=BaseMockConnection(), connection_parameters=manager.servers[0]),
-        mock.call(connection=BaseMockConnection(), connection_parameters=manager.servers[0]),
+        mock.call(
+            connection=BaseMockConnection(),
+            connection_parameters=manager.servers[0],
+            set_heartbeat_interval=manager._restart_heartbeat_tasks,
+        ),
+        mock.call(
+            connection=BaseMockConnection(),
+            connection_parameters=manager.servers[0],
+            set_heartbeat_interval=manager._restart_heartbeat_tasks,
+        ),
     ]
 
 

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -132,7 +132,7 @@ async def test_connect_to_any_server_fails() -> None:
 
 
 async def test_get_active_connection_state_lifespan_flaky_ok() -> None:
-    enter = mock.AsyncMock(side_effect=[ConnectionLostError, None])
+    enter = mock.AsyncMock(side_effect=[ConnectionLostError, build_dataclass(EstablishedConnectionResult)])
     lifespan_factory = mock.Mock(return_value=mock.Mock(enter=enter))
     manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=BaseMockConnection)
 
@@ -206,7 +206,8 @@ async def test_connection_manager_context_lifespan_aexit_raises_connection_lost(
     async with EnrichedConnectionManager(
         lifespan_factory=mock.Mock(
             return_value=mock.Mock(
-                enter=mock.AsyncMock(return_value=None), exit=mock.AsyncMock(side_effect=[ConnectionLostError])
+                enter=mock.AsyncMock(return_value=build_dataclass(EstablishedConnectionResult)),
+                exit=mock.AsyncMock(side_effect=[ConnectionLostError]),
             )
         ),
         connection_class=BaseMockConnection,
@@ -222,7 +223,11 @@ async def test_connection_manager_context_exits_ok() -> None:
         close = connection_close
 
     async with EnrichedConnectionManager(
-        lifespan_factory=mock.Mock(return_value=mock.Mock(enter=mock.AsyncMock(return_value=None), exit=close)),
+        lifespan_factory=mock.Mock(
+            return_value=mock.Mock(
+                enter=mock.AsyncMock(return_value=build_dataclass(EstablishedConnectionResult)), exit=close
+            )
+        ),
         connection_class=MockConnection,
     ):
         pass

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -165,9 +165,7 @@ async def test_client_listen_routing_ok(monkeypatch: pytest.MonkeyPatch, faker: 
     second_message_handler, second_error_handler = mock.AsyncMock(side_effect=SomeError), mock.Mock()
 
     async with EnrichedClient(
-        connection_class=connection_class,
-        on_error_frame=(on_error_frame := mock.Mock()),
-        on_heartbeat=(on_heartbeat := mock.Mock()),
+        connection_class=connection_class, on_error_frame=(on_error_frame := mock.Mock())
     ) as client:
         first_subscription = await client.subscribe(
             faker.pystr(), handler=first_message_handler, on_suppressed_exception=first_error_handler
@@ -187,7 +185,6 @@ async def test_client_listen_routing_ok(monkeypatch: pytest.MonkeyPatch, faker: 
     second_error_handler.assert_called_once_with(SomeError(), third_message_frame)
 
     on_error_frame.assert_called_once_with(error_frame)
-    on_heartbeat.assert_called_once_with()
 
 
 @pytest.mark.parametrize("side_effect", [None, SomeError])

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -325,7 +325,11 @@ async def test_client_listen_raises_on_aexit(monkeypatch: pytest.MonkeyPatch, fa
     assert isinstance(inner_group, ExceptionGroup)
     assert len(inner_group.exceptions) == 1
 
-    assert isinstance(inner_group.exceptions[0], FailedAllConnectAttemptsError)
+    inner_inner_group = inner_group.exceptions[0]
+    assert isinstance(inner_inner_group, ExceptionGroup)
+    assert len(inner_inner_group.exceptions) == 1
+
+    assert isinstance(inner_inner_group.exceptions[0], FailedAllConnectAttemptsError)
 
 
 def test_make_subscription_id() -> None:


### PR DESCRIPTION
- Add reconnection when server doesn't send heart-beats
- Add `Client.is_alive()` to check if server responds
- Remove `on_heartbeat` callback: it is not needed anymore
- Use `Client.is_alive` in FastStream integration (`StompBroker.ping()`)

---

I've struggled to add proper tests. `Client.is_alive()` is fully tested, but reconnection logic — that I couldn't test, sadly.
