### PR TITLE
Allow subscriptions to be removed asynchronously

### DIFF
--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -16,34 +16,34 @@ from stompman.frames import (
 )
 
 
-@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
+@dataclass(kw_only=True, slots=True, frozen=True)
 class ActiveSubscriptions:
-    subscriptions: dict[str, AutoAckSubscription | ManualAckSubscription] = dataclasses.field(default_factory=dict, init=False)
-    event: Event = dataclasses.field(default_factory=Event, init=False)
+    subscriptions: dict[str, "AutoAckSubscription | ManualAckSubscription"] = field(default_factory=dict, init=False)
+    event: asyncio.Event = field(default_factory=asyncio.Event, init=False)
 
     def __post_init__(self) -> None:
         self.event.set()
 
     def get_by_id(self, subscription_id: str) -> "AutoAckSubscription | ManualAckSubscription | None":
-        return self._subscriptions.get(subscription_id)
+        return self.subscriptions.get(subscription_id)
 
     def get_all(self) -> list["AutoAckSubscription | ManualAckSubscription"]:
-        return list(self._subscriptions.values())
+        return list(self.subscriptions.values())
 
     def delete_by_id(self, subscription_id: str) -> None:
-        del self._subscriptions[subscription_id]
-        if not self._subscriptions:
-            self._event.set()
+        del self.subscriptions[subscription_id]
+        if not self.subscriptions:
+            self.event.set()
 
     def add(self, subscription: "AutoAckSubscription | ManualAckSubscription") -> None:
-        self._subscriptions[subscription.id] = subscription
-        self._event.clear()
+        self.subscriptions[subscription.id] = subscription
+        self.event.clear()
 
     def contains_by_id(self, subscription_id: str) -> bool:
-        return subscription_id in self._subscriptions
+        return subscription_id in self.subscriptions
 
     async def wait_until_empty(self) -> bool:
-        return await self._event.wait()
+        return await self.event.wait()
 
 
 @dataclass(kw_only=True, slots=True)

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -16,11 +16,13 @@ from stompman.frames import (
 )
 
 
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class ActiveSubscriptions:
-    def __init__(self) -> None:
-        self._subscriptions: dict[str, AutoAckSubscription | ManualAckSubscription] = {}
-        self._event = Event()
-        self._event.set()
+    subscriptions: dict[str, AutoAckSubscription | ManualAckSubscription] = dataclasses.field(default_factory=dict, init=False)
+    event: Event = dataclasses.field(default_factory=Event, init=False)
+
+    def __post_init__(self) -> None:
+        self.event.set()
 
     def get_by_id(self, subscription_id: str) -> "AutoAckSubscription | ManualAckSubscription | None":
         return self._subscriptions.get(subscription_id)

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -1,3 +1,4 @@
+from asyncio import Event
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
@@ -14,7 +15,33 @@ from stompman.frames import (
     UnsubscribeFrame,
 )
 
-ActiveSubscriptions = dict[str, "AutoAckSubscription | ManualAckSubscription"]
+
+class ActiveSubscriptions:
+    def __init__(self) -> None:
+        self._subscriptions: dict[str, AutoAckSubscription | ManualAckSubscription] = {}
+        self._event = Event()
+        self._event.set()
+
+    def get_by_id(self, subscription_id: str) -> "AutoAckSubscription | ManualAckSubscription | None":
+        return self._subscriptions.get(subscription_id)
+
+    def get_all(self) -> list["AutoAckSubscription | ManualAckSubscription"]:
+        return list(self._subscriptions.values())
+
+    def delete_by_id(self, subscription_id: str) -> None:
+        del self._subscriptions[subscription_id]
+        if not self._subscriptions:
+            self._event.set()
+
+    def add(self, subscription: "AutoAckSubscription | ManualAckSubscription") -> None:
+        self._subscriptions[subscription.id] = subscription
+        self._event.clear()
+
+    def contains_by_id(self, subscription_id: str) -> bool:
+        return subscription_id in self._subscriptions
+
+    async def wait_until_empty(self) -> bool:
+        return await self._event.wait()
 
 
 @dataclass(kw_only=True, slots=True)
@@ -32,20 +59,20 @@ class BaseSubscription:
                 subscription_id=self.id, destination=self.destination, ack=self.ack, headers=self.headers
             )
         )
-        self._active_subscriptions[self.id] = self  # type: ignore[assignment]
+        self._active_subscriptions.add(self)  # type: ignore[arg-type]
 
     async def unsubscribe(self) -> None:
-        del self._active_subscriptions[self.id]
+        self._active_subscriptions.delete_by_id(self.id)
         await self._connection_manager.maybe_write_frame(UnsubscribeFrame(headers={"id": self.id}))
 
     async def _nack(self, frame: MessageFrame) -> None:
-        if self.id in self._active_subscriptions and (ack_id := frame.headers.get("ack")):
+        if self._active_subscriptions.contains_by_id(self.id) and (ack_id := frame.headers.get("ack")):
             await self._connection_manager.maybe_write_frame(
                 NackFrame(headers={"id": ack_id, "subscription": frame.headers["subscription"]})
             )
 
     async def _ack(self, frame: MessageFrame) -> None:
-        if self.id in self._active_subscriptions and (ack_id := frame.headers["ack"]):
+        if self._active_subscriptions.contains_by_id(self.id) and (ack_id := frame.headers["ack"]):
             await self._connection_manager.maybe_write_frame(
                 AckFrame(headers={"id": ack_id, "subscription": frame.headers["subscription"]})
             )
@@ -96,7 +123,7 @@ def _make_subscription_id() -> str:
 async def resubscribe_to_active_subscriptions(
     *, connection: AbstractConnection, active_subscriptions: ActiveSubscriptions
 ) -> None:
-    for subscription in active_subscriptions.values():
+    for subscription in active_subscriptions.get_all():
         await connection.write_frame(
             SubscribeFrame.build(
                 subscription_id=subscription.id,
@@ -108,5 +135,5 @@ async def resubscribe_to_active_subscriptions(
 
 
 async def unsubscribe_from_all_active_subscriptions(*, active_subscriptions: ActiveSubscriptions) -> None:
-    for subscription in active_subscriptions.copy().values():
+    for subscription in active_subscriptions.get_all():
         await subscription.unsubscribe()

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -1,4 +1,4 @@
-from asyncio import Event
+import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any

--- a/packages/stompman/test_stompman/test_send.py
+++ b/packages/stompman/test_stompman/test_send.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import Any
 
-import faker
 import pytest
 from stompman import (
     SendFrame,

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -365,8 +365,7 @@ async def test_client_exits_when_subscriptions_are_unsubscribed(
             wait_and_unsubscribe(first_subscription, second_subscription, wait_in_seconds=0.5)
         )
 
-    if not unsubscribe_task.done():
-        pytest.fail("Client should exit context manager only when subscriptions are unsubscribed")
+    assert unsubscribe_task.done(), "Client should exit context manager only when subscriptions are unsubscribed"
 
     assert collected_frames == enrich_expected_frames(
         SubscribeFrame(headers={"id": first_id, "destination": first_destination, "ack": "client-individual"}),


### PR DESCRIPTION
See https://github.com/community-of-python/stompman/issues/120 ; `Client.__aexit__` now blocks on an `Event` which is set when all the subscriptions are removed