### PR TITLE
Remove `read_timeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ async with stompman.Client(
     connect_timeout=2,
     connection_confirmation_timeout=2,
     disconnect_confirmation_timeout=2,
-    read_timeout=2,
     write_retry_attempts=3,
     check_server_alive_interval_factor=3,
 ) as client:
@@ -144,7 +143,7 @@ Also, I want to pointed out that:
 
 - Protocol parsing is inspired by [aiostomp](https://github.com/pedrokiefer/aiostomp/blob/3449dcb53f43e5956ccc7662bb5b7d76bc6ef36b/aiostomp/protocol.py) (meaning: consumed by me and refactored from).
 - stompman is tested and used with [ActiveMQ Artemis](https://activemq.apache.org/components/artemis/) and [ActiveMQ Classic](https://activemq.apache.org/components/classic/).
-    - Caveat: a message sent by a Stomp client is converted into a JMS `TextMessage`/`BytesMessage` based on the `content-length` header (see the docs [here](https://activemq.apache.org/components/classic/documentation/stomp)). In order to send a `TextMessage`, `Client.send` needs to be invoked with `add_content_length` header set to `False` 
+    - Caveat: a message sent by a Stomp client is converted into a JMS `TextMessage`/`BytesMessage` based on the `content-length` header (see the docs [here](https://activemq.apache.org/components/classic/documentation/stomp)). In order to send a `TextMessage`, `Client.send` needs to be invoked with `add_content_length` header set to `False`
 - Specification says that headers in CONNECT and CONNECTED frames shouldn't be escaped for backwards compatibility. stompman escapes headers in CONNECT frame (outcoming), but does not unescape headers in CONNECTED (outcoming).
 
 ### FastStream STOMP broker

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import platform
 from typing import cast
 
 import pytest
@@ -24,6 +25,10 @@ def first_server_connection_parameters() -> stompman.ConnectionParameters:
         stompman.ConnectionParameters(host="127.0.0.1", port=9000, login="admin", passcode=":=123"),
         stompman.ConnectionParameters(host="127.0.0.1", port=9001, login="admin", passcode=":=123"),
     ]
+    if platform.platform() == "Linux"  # TODO: fix tests with ActiveMQ Classic on Mac  # noqa: FIX002, TD002, TD003
+    else [
+        stompman.ConnectionParameters(host="127.0.0.1", port=9000, login="admin", passcode=":=123"),
+    ],
 )
 def connection_parameters(request: pytest.FixtureRequest) -> stompman.ConnectionParameters:
     return cast("stompman.ConnectionParameters", request.param)

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -36,7 +36,6 @@ class Client:
     connect_retry_attempts: int = 3
     connect_retry_interval: int = 1
     connect_timeout: int = 2
-    read_timeout: int = 2
     read_max_chunk_size: int = 1024 * 1024
     write_retry_attempts: int = 3
     connection_confirmation_timeout: int = 2
@@ -69,7 +68,6 @@ class Client:
             connect_retry_attempts=self.connect_retry_attempts,
             connect_retry_interval=self.connect_retry_interval,
             connect_timeout=self.connect_timeout,
-            read_timeout=self.read_timeout,
             read_max_chunk_size=self.read_max_chunk_size,
             write_retry_attempts=self.write_retry_attempts,
             check_server_alive_interval_factor=self.check_server_alive_interval_factor,

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -46,7 +46,6 @@ class ConnectionManager:
     connect_retry_interval: int
     connect_timeout: int
     ssl: Literal[True] | SSLContext | None
-    read_timeout: int
     read_max_chunk_size: int
     write_retry_attempts: int
     check_server_alive_interval_factor: int
@@ -113,7 +112,6 @@ class ConnectionManager:
             port=server.port,
             timeout=self.connect_timeout,
             read_max_chunk_size=self.read_max_chunk_size,
-            read_timeout=self.read_timeout,
             ssl=self.ssl,
         ):
             return (connection, server)

--- a/packages/stompman/test_stompman/conftest.py
+++ b/packages/stompman/test_stompman/conftest.py
@@ -34,7 +34,6 @@ class BaseMockConnection(AbstractConnection):
         port: int,
         timeout: int,
         read_max_chunk_size: int,
-        read_timeout: int,
         ssl: Literal[True] | SSLContext | None,
     ) -> Self | None:
         return cls()
@@ -76,7 +75,6 @@ class EnrichedConnectionManager(ConnectionManager):
     connect_retry_attempts: int = 3
     connect_retry_interval: int = 1
     connect_timeout: int = 3
-    read_timeout: int = 4
     read_max_chunk_size: int = 5
     write_retry_attempts: int = 3
     ssl: Literal[True] | SSLContext | None = None

--- a/packages/stompman/test_stompman/test_connection.py
+++ b/packages/stompman/test_stompman/test_connection.py
@@ -1,7 +1,6 @@
 import asyncio
 import socket
 from collections.abc import Awaitable
-from functools import partial
 from typing import Any
 from unittest import mock
 
@@ -147,15 +146,6 @@ async def test_connection_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_connection_connect_connection_error(monkeypatch: pytest.MonkeyPatch, exception: type[Exception]) -> None:
     monkeypatch.setattr("asyncio.open_connection", mock.AsyncMock(side_effect=exception))
     assert not await make_connection()
-
-
-async def test_read_frames_timeout_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    connection = await make_mocked_connection(
-        monkeypatch, mock.AsyncMock(read=partial(asyncio.sleep, 5)), mock.AsyncMock()
-    )
-    mock_wait_for(monkeypatch)
-    with pytest.raises(ConnectionLostError):
-        [frame async for frame in connection.read_frames()]
 
 
 async def test_read_frames_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/stompman/test_stompman/test_connection.py
+++ b/packages/stompman/test_stompman/test_connection.py
@@ -21,9 +21,7 @@ pytestmark = pytest.mark.anyio
 
 
 async def make_connection() -> Connection | None:
-    return await Connection.connect(
-        host="localhost", port=12345, timeout=2, read_max_chunk_size=1024 * 1024, read_timeout=2, ssl=None
-    )
+    return await Connection.connect(host="localhost", port=12345, timeout=2, read_max_chunk_size=1024 * 1024, ssl=None)
 
 
 async def make_mocked_connection(monkeypatch: pytest.MonkeyPatch, reader: object, writer: object) -> Connection:

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -42,7 +42,6 @@ async def test_connect_attempts_ok(ok_on_attempt: int, monkeypatch: pytest.Monke
             port: int,
             timeout: int,
             read_max_chunk_size: int,
-            read_timeout: int,
             ssl: Literal[True] | SSLContext | None,
         ) -> Self | None:
             assert (host, port) == (manager.servers[0].host, manager.servers[0].port)
@@ -55,7 +54,6 @@ async def test_connect_attempts_ok(ok_on_attempt: int, monkeypatch: pytest.Monke
                     port=port,
                     timeout=timeout,
                     read_max_chunk_size=read_max_chunk_size,
-                    read_timeout=read_timeout,
                     ssl=ssl,
                 )
                 if attempts == ok_on_attempt
@@ -88,7 +86,6 @@ async def test_connect_to_any_server_ok() -> None:
             port: int,
             timeout: int,
             read_max_chunk_size: int,
-            read_timeout: int,
             ssl: Literal[True] | SSLContext | None,
         ) -> Self | None:
             return (
@@ -97,7 +94,6 @@ async def test_connect_to_any_server_ok() -> None:
                     port=port,
                     timeout=timeout,
                     read_max_chunk_size=read_max_chunk_size,
-                    read_timeout=read_timeout,
                     ssl=ssl,
                 )
                 if port == successful_server.port

--- a/packages/stompman/test_stompman/test_integration.py
+++ b/packages/stompman/test_stompman/test_integration.py
@@ -24,9 +24,7 @@ DESTINATION: Final = "DLQ"
 
 @asynccontextmanager
 async def create_client(connection_parameters: stompman.ConnectionParameters) -> AsyncGenerator[stompman.Client, None]:
-    async with stompman.Client(
-        servers=[connection_parameters], read_timeout=10, connection_confirmation_timeout=10
-    ) as client:
+    async with stompman.Client(servers=[connection_parameters], connection_confirmation_timeout=10) as client:
         yield client
 
 


### PR DESCRIPTION
As @tristanpye proves in #122, the `read_timeout` parameter is not needed when we that server is alive (we started doing that in #109, #110) 