### PR TITLE
Keep client alive after connection recovery fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ async with stompman.Client(
     write_retry_attempts=3,
     check_server_alive_interval_factor=3,
     no_message_restart_interval=datetime.timedelta(hours=1),  # None to disable
+    keep_alive_on_connection_failure=False,
 ) as client:
     ...
 ```
@@ -150,6 +151,7 @@ stompman takes care of cleaning up resources automatically. When you leave the c
 - If multiple servers were provided, stompman will attempt to connect to each one simultaneously and will use the first that succeeds. If all servers fail to connect, an `stompman.FailedAllConnectAttemptsError` will be raised. In normal situation it doesn't need to be handled: tune retry and timeout parameters in `stompman.Client()` to your needs.
 
 - When connection is lost, stompman will attempt to handle it automatically. `stompman.FailedAllConnectAttemptsError` will be raised if all connection attempts fail. `stompman.FailedAllWriteAttemptsError` will be raised if connection succeeds but sending a frame or heartbeat lead to losing connection.
+- Set `keep_alive_on_connection_failure=True` to keep background heartbeat and read recovery running after a retry cycle is exhausted. The default remains `False`, and errors from `Client.send()` still follow `connect_retry_attempts` and `write_retry_attempts`.
 - If no messages are received for `no_message_restart_interval` (defaults to 1 hour), stompman will force a reconnect. Set to `None` to disable.
 - To implement health checks, use `stompman.Client.is_alive()` — it will return `True` if everything is OK and `False` if server is not responding.
 - `stompman` will write log warnings when connection is lost, after successful reconnection or invalid state during ack/nack.

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -30,7 +30,7 @@ from stompman.transaction import Transaction
 async def _run_handler_with_safety_net(coro: Coroutine[Any, Any, Any]) -> None:
     try:
         await coro
-    except Exception:  # noqa: BLE001
+    except Exception:  # ruff: ignore[blind-except]
         LOGGER.exception("unhandled exception in message handler")
 
 
@@ -56,6 +56,8 @@ class Client:
     """Client will check if server alive `server heartbeat interval` times `interval factor`"""
     no_message_restart_interval: timedelta | None = timedelta(hours=1)
     """Force reconnect if no messages received within this interval. None to disable."""
+    keep_alive_on_connection_failure: bool = False
+    """Keep background connection recovery alive after a retry cycle is exhausted."""
     max_concurrent_handlers: int | None = 100
     """Cap on concurrently-running message handlers. Set to None to disable the cap."""
 
@@ -89,6 +91,7 @@ class Client:
             write_retry_attempts=self.write_retry_attempts,
             check_server_alive_interval_factor=self.check_server_alive_interval_factor,
             no_message_restart_interval=self.no_message_restart_interval,
+            keep_alive_on_connection_failure=self.keep_alive_on_connection_failure,
             ssl=self.ssl,
         )
         if self.max_concurrent_handlers is not None:

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -61,6 +61,7 @@ class ConnectionManager:
     write_retry_attempts: int
     check_server_alive_interval_factor: int
     no_message_restart_interval: timedelta | None
+    keep_alive_on_connection_failure: bool = False
 
     _active_connection_state: ActiveConnectionState | None = field(default=None, init=False)
     _reconnect_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
@@ -85,15 +86,23 @@ class ConnectionManager:
             self._monitor_no_message_task.cancel()
             tasks.append(self._monitor_no_message_task)
         await asyncio.wait(tasks)
-        await self._task_group.__aexit__(exc_type, exc_value, traceback)
+        try:
+            await self._task_group.__aexit__(exc_type, exc_value, traceback)
+        finally:
+            await self._close_active_connection_state()
 
-        if not self._active_connection_state:
+    async def _close_active_connection_state(self) -> None:
+        connection_state = self._active_connection_state
+        if connection_state is None:
             return
         try:
-            await self._active_connection_state.lifespan.exit()
+            await connection_state.lifespan.exit()
         except ConnectionLostError:
-            return
-        await self._active_connection_state.connection.close()
+            pass
+        finally:
+            if self._active_connection_state is connection_state:
+                self._active_connection_state = None
+            await connection_state.connection.close()
 
     def _restart_background_tasks(self, server_heartbeat: Heartbeat) -> None:
         self._send_heartbeat_task.cancel()
@@ -112,8 +121,15 @@ class ConnectionManager:
     async def _send_heartbeats_forever(self, send_heartbeat_interval_ms: int) -> None:
         send_heartbeat_interval_seconds = send_heartbeat_interval_ms / 1000
         while True:
-            await self.write_heartbeat_reconnecting()
-            await asyncio.sleep(send_heartbeat_interval_seconds)
+            try:
+                await self.write_heartbeat_reconnecting()
+            except (FailedAllConnectAttemptsError, FailedAllWriteAttemptsError) as error:
+                if not self.keep_alive_on_connection_failure:
+                    raise
+                LOGGER.warning("background heartbeat recovery exhausted; keeping client alive. error: %r", error)
+                await asyncio.sleep(self.connect_retry_interval)
+            else:
+                await asyncio.sleep(send_heartbeat_interval_seconds)
 
     async def _monitor_no_message_timeout(self, interval: timedelta) -> None:
         interval_seconds = interval.total_seconds()
@@ -127,10 +143,10 @@ class ConnectionManager:
                         "no messages received for %s seconds, forcing reconnect",
                         interval_seconds,
                     )
-                    self._clear_active_connection_state(
-                        ConnectionLostError(reason="no messages received within timeout")
+                    await self._discard_failed_connection_state(
+                        connection_state,
+                        ConnectionLostError(reason="no messages received within timeout"),
                     )
-                    await connection_state.connection.close()
                 await asyncio.sleep(interval_seconds)
 
     async def _create_connection_to_one_server(
@@ -156,7 +172,7 @@ class ConnectionManager:
         return None
 
     async def _connect_to_any_server(self) -> ActiveConnectionState | AnyConnectionIssue:
-        from stompman.connection_lifespan import EstablishedConnectionResult  # noqa: PLC0415
+        from stompman.connection_lifespan import EstablishedConnectionResult  # ruff: ignore[import-outside-top-level]
 
         if not (connection_and_server := await self._create_connection_to_any_server()):
             return AllServersUnavailable(servers=self.servers, timeout=self.connect_timeout)
@@ -167,21 +183,25 @@ class ConnectionManager:
             set_heartbeat_interval=self._restart_background_tasks,
         )
 
+        connection_established = False
         try:
-            connection_result = await lifespan.enter()
-        except ConnectionLostError:
-            return ConnectionLostOnLifespanEnter()
+            try:
+                connection_result = await lifespan.enter()
+            except ConnectionLostError:
+                return ConnectionLostOnLifespanEnter()
 
-        return (
-            ActiveConnectionState(
-                connection=connection,
-                lifespan=lifespan,
-                server_heartbeat=connection_result.server_heartbeat,
-                connected_at=time.time(),
-            )
-            if isinstance(connection_result, EstablishedConnectionResult)
-            else connection_result
-        )
+            if isinstance(connection_result, EstablishedConnectionResult):
+                connection_established = True
+                return ActiveConnectionState(
+                    connection=connection,
+                    lifespan=lifespan,
+                    server_heartbeat=connection_result.server_heartbeat,
+                    connected_at=time.time(),
+                )
+            return connection_result
+        finally:
+            if not connection_established:
+                await connection.close()
 
     async def _get_active_connection_state(self, *, is_initial_call: bool = False) -> ActiveConnectionState:
         if self._active_connection_state:
@@ -212,16 +232,21 @@ class ConnectionManager:
 
         raise FailedAllConnectAttemptsError(retry_attempts=self.connect_retry_attempts, issues=connection_issues)
 
-    def _clear_active_connection_state(self, error_reason: ConnectionLostError) -> None:
-        if not self._active_connection_state:
+    async def _discard_failed_connection_state(
+        self,
+        connection_state: ActiveConnectionState,
+        error_reason: ConnectionLostError,
+    ) -> None:
+        if self._active_connection_state is not connection_state:
             return
         LOGGER.warning(
             "connection lost. reason: %r, connection_parameters: %s",
             error_reason.reason,
-            self._active_connection_state.lifespan.connection_parameters,
+            connection_state.lifespan.connection_parameters,
         )
         self._active_connection_state = None
         self._reconnection_count += 1
+        await connection_state.connection.close()
 
     async def write_heartbeat_reconnecting(self) -> None:
         for _ in range(self.write_retry_attempts):
@@ -229,7 +254,7 @@ class ConnectionManager:
             try:
                 return connection_state.connection.write_heartbeat()
             except ConnectionLostError as error:
-                self._clear_active_connection_state(error)
+                await self._discard_failed_connection_state(connection_state, error)
 
         raise FailedAllWriteAttemptsError(retry_attempts=self.write_retry_attempts)
 
@@ -239,28 +264,35 @@ class ConnectionManager:
             try:
                 return await connection_state.connection.write_frame(frame)
             except ConnectionLostError as error:
-                self._clear_active_connection_state(error)
+                await self._discard_failed_connection_state(connection_state, error)
 
         raise FailedAllWriteAttemptsError(retry_attempts=self.write_retry_attempts)
 
     async def read_frames_reconnecting(self) -> AsyncGenerator[tuple[AnyServerFrame, int], None]:
         while True:
-            connection_state = await self._get_active_connection_state()
+            try:
+                connection_state = await self._get_active_connection_state()
+            except FailedAllConnectAttemptsError as error:
+                if not self.keep_alive_on_connection_failure:
+                    raise
+                LOGGER.warning("background read recovery exhausted; keeping client alive. error: %r", error)
+                await asyncio.sleep(self.connect_retry_interval)
+                continue
             epoch = self._reconnection_count
             try:
                 async for frame in connection_state.connection.read_frames():
                     yield frame, epoch
             except ConnectionLostError as error:
-                self._clear_active_connection_state(error)
+                await self._discard_failed_connection_state(connection_state, error)
 
     async def maybe_write_frame(self, frame: AnyClientFrame) -> bool:
-        if not self._active_connection_state:
+        if not (connection_state := self._active_connection_state):
             _log_dropped_frame(frame, reason="no active connection")
             return False
         try:
-            await self._active_connection_state.connection.write_frame(frame)
+            await connection_state.connection.write_frame(frame)
         except ConnectionLostError as error:
             _log_dropped_frame(frame, reason="connection lost mid-write")
-            self._clear_active_connection_state(error)
+            await self._discard_failed_connection_state(connection_state, error)
             return False
         return True

--- a/packages/stompman/test_stompman/conftest.py
+++ b/packages/stompman/test_stompman/conftest.py
@@ -26,6 +26,15 @@ async def noop_message_handler(frame: stompman.MessageFrame) -> None: ...
 def noop_error_handler(exception: Exception, frame: stompman.MessageFrame) -> None: ...
 
 
+async def drop_active_connection(client: stompman.Client) -> None:
+    connection_state = client._connection_manager._active_connection_state
+    assert connection_state is not None
+    await client._connection_manager._discard_failed_connection_state(
+        connection_state,
+        stompman.ConnectionLostError(reason="test connection loss"),
+    )
+
+
 class BaseMockConnection(AbstractConnection):
     @classmethod
     async def connect(
@@ -83,12 +92,13 @@ class EnrichedConnectionManager(ConnectionManager):
     ssl: Literal[True] | SSLContext | None = None
     check_server_alive_interval_factor: int = 3
     no_message_restart_interval: timedelta | None = None
+    keep_alive_on_connection_failure: bool = False
 
 
 DataclassType = TypeVar("DataclassType")
 
 
-def build_dataclass(dataclass: type[DataclassType], **kwargs: Any) -> DataclassType:  # noqa: ANN401
+def build_dataclass(dataclass: type[DataclassType], **kwargs: Any) -> DataclassType:  # ruff: ignore[any-type]
     return DataclassFactory.create_factory(dataclass).build(**kwargs)
 
 

--- a/packages/stompman/test_stompman/test_connection_lifespan.py
+++ b/packages/stompman/test_stompman/test_connection_lifespan.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import AsyncGenerator, Coroutine
-from typing import Any, cast
+from ssl import SSLContext
+from typing import TYPE_CHECKING, Any, Literal, Self, cast
 from unittest import mock
 
 import faker
@@ -12,11 +13,14 @@ from stompman import (
     ConnectedFrame,
     ConnectFrame,
     ConnectionConfirmationTimeout,
+    ConnectionLostError,
     ConnectionParameters,
     DisconnectFrame,
     ErrorFrame,
     FailedAllConnectAttemptsError,
+    Heartbeat,
     ReceiptFrame,
+    SendFrame,
     UnsupportedProtocolVersion,
 )
 
@@ -27,6 +31,9 @@ from test_stompman.conftest import (
     create_spying_connection,
     get_read_frames_with_lifespan,
 )
+
+if TYPE_CHECKING:
+    from stompman.connection import AbstractConnection
 
 pytestmark = pytest.mark.anyio
 
@@ -178,6 +185,89 @@ async def test_client_heartbeats_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert sleep_calls == [0, 1, 1, 1]
     assert write_heartbeat_mock.mock_calls == [mock.call(), mock.call(), mock.call(), mock.call()]
+
+
+async def test_client_recovers_after_heartbeat_failure_when_keep_alive_enabled() -> None:  # ruff: ignore[complex-structure]
+    expected_connection_count = 2
+    heartbeat_failed = asyncio.Event()
+    second_connection_established = asyncio.Event()
+    sent_connection_numbers: list[int] = []
+    closed_connection_numbers: list[int] = []
+    connection_count = 0
+
+    class RecoveringConnection:
+        last_read_time: float | None = None
+
+        def __init__(self) -> None:
+            nonlocal connection_count
+            connection_count += 1
+            self.connection_number = connection_count
+            self.closed = asyncio.Event()
+            self.disconnect_sent = False
+            self.read_count = 0
+
+        @classmethod
+        async def connect(
+            cls,
+            *,
+            host: str,
+            port: int,
+            timeout: int,
+            read_max_chunk_size: int,
+            ssl: Literal[True] | SSLContext | None,
+            ws_uri_path: str | None = None,
+        ) -> Self:
+            del host, port, timeout, read_max_chunk_size, ssl, ws_uri_path
+            return cls()
+
+        async def close(self) -> None:
+            if self.closed.is_set():
+                return
+            closed_connection_numbers.append(self.connection_number)
+            self.closed.set()
+
+        def write_heartbeat(self) -> None:
+            if self.connection_number == 1 and not heartbeat_failed.is_set():
+                heartbeat_failed.set()
+                raise ConnectionLostError(reason="induced heartbeat failure")
+
+        async def write_frame(self, frame: stompman.AnyClientFrame) -> None:
+            if isinstance(frame, DisconnectFrame):
+                self.disconnect_sent = True
+            elif isinstance(frame, SendFrame):
+                sent_connection_numbers.append(self.connection_number)
+
+        async def read_frames(self) -> AsyncGenerator[AnyServerFrame, None]:
+            self.read_count += 1
+            if self.read_count == 1:
+                if self.connection_number == expected_connection_count:
+                    second_connection_established.set()
+                yield ConnectedFrame(headers={"version": Client.PROTOCOL_VERSION, "heart-beat": "1,1"})
+                return
+            if self.disconnect_sent:
+                yield ReceiptFrame(headers={"receipt-id": "receipt-id-1"})
+                return
+            await self.closed.wait()
+            raise ConnectionLostError(reason="closed")
+
+    async with EnrichedClient(
+        connection_class=cast("type[AbstractConnection]", RecoveringConnection),
+        heartbeat=Heartbeat(will_send_interval_ms=1, want_to_receive_interval_ms=1),
+        connect_retry_attempts=1,
+        connect_retry_interval=0,
+        write_retry_attempts=1,
+        keep_alive_on_connection_failure=True,
+    ) as client:
+        await asyncio.wait_for(heartbeat_failed.wait(), timeout=1)
+        await asyncio.wait_for(second_connection_established.wait(), timeout=1)
+        await asyncio.sleep(0)
+
+        await client.send(b"payload", destination="queue")
+
+        assert not client._listen_task.done()
+        assert sent_connection_numbers == [expected_connection_count]
+
+    assert closed_connection_numbers == [1, expected_connection_count]
 
 
 def test_make_receipt_id(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -162,9 +162,14 @@ async def test_get_active_connection_state_lifespan_flaky_ok() -> None:
 
 
 async def test_get_active_connection_state_lifespan_flaky_fails() -> None:
+    connection_close = mock.AsyncMock()
+
+    class MockConnection(BaseMockConnection):
+        close = connection_close
+
     enter = mock.AsyncMock(side_effect=build_dataclass(ConnectionLostError))
     lifespan_factory = mock.Mock(return_value=mock.Mock(enter=enter))
-    manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=BaseMockConnection)
+    manager = EnrichedConnectionManager(lifespan_factory=lifespan_factory, connection_class=MockConnection)
 
     with pytest.raises(FailedAllConnectAttemptsError) as exc_info:
         await manager._get_active_connection_state()
@@ -175,6 +180,7 @@ async def test_get_active_connection_state_lifespan_flaky_fails() -> None:
         == len(enter.mock_calls)
         == manager.connect_retry_attempts
     )
+    assert connection_close.await_count == manager.connect_retry_attempts
 
 
 async def test_get_active_connection_state_fails_to_connect() -> None:
@@ -220,11 +226,18 @@ async def test_get_active_connection_state_ok_concurrent() -> None:
 
 async def test_connection_manager_context_connection_lost() -> None:
     async with EnrichedConnectionManager(connection_class=BaseMockConnection) as manager:
-        manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
-        manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
+        connection_state = manager._active_connection_state
+        assert connection_state is not None
+        await manager._discard_failed_connection_state(connection_state, build_dataclass(ConnectionLostError))
+        await manager._discard_failed_connection_state(connection_state, build_dataclass(ConnectionLostError))
 
 
 async def test_connection_manager_context_lifespan_aexit_raises_connection_lost() -> None:
+    connection_close = mock.AsyncMock()
+
+    class MockConnection(BaseMockConnection):
+        close = connection_close
+
     async with EnrichedConnectionManager(
         lifespan_factory=mock.Mock(
             return_value=mock.Mock(
@@ -232,9 +245,11 @@ async def test_connection_manager_context_lifespan_aexit_raises_connection_lost(
                 exit=mock.AsyncMock(side_effect=[build_dataclass(ConnectionLostError)]),
             )
         ),
-        connection_class=BaseMockConnection,
+        connection_class=MockConnection,
     ):
         pass
+
+    connection_close.assert_awaited_once_with()
 
 
 async def test_connection_manager_context_exits_ok() -> None:
@@ -258,6 +273,29 @@ async def test_connection_manager_context_exits_ok() -> None:
     connection_close.assert_called_once_with()
 
 
+async def test_connection_manager_context_closes_connection_after_background_failure() -> None:
+    connection_close = mock.AsyncMock()
+
+    class MockConnection(BaseMockConnection):
+        close = connection_close
+
+    async def fail_background_task() -> None:
+        await asyncio.sleep(0)
+        raise FailedAllWriteAttemptsError(retry_attempts=1)
+
+    manager = EnrichedConnectionManager(connection_class=MockConnection)
+
+    async def run_manager() -> None:
+        async with manager:
+            manager._task_group.create_task(fail_background_task())
+            await asyncio.Event().wait()
+
+    (result,) = await asyncio.gather(asyncio.create_task(run_manager()), return_exceptions=True)
+
+    assert isinstance(result, ExceptionGroup)
+    connection_close.assert_awaited_once_with()
+
+
 async def test_write_heartbeat_reconnecting_raises() -> None:
     write_heartbeat_mock = mock.Mock(
         side_effect=[
@@ -276,7 +314,126 @@ async def test_write_heartbeat_reconnecting_raises() -> None:
         await manager.write_heartbeat_reconnecting()
 
 
+async def test_write_heartbeat_reconnecting_closes_failed_connections() -> None:
+    connection_close = mock.AsyncMock()
+
+    class MockConnection(BaseMockConnection):
+        close = connection_close
+        write_heartbeat = mock.Mock(side_effect=build_dataclass(ConnectionLostError))
+
+    manager = EnrichedConnectionManager(connection_class=MockConnection, write_retry_attempts=1)
+
+    with pytest.raises(FailedAllWriteAttemptsError):
+        await manager.write_heartbeat_reconnecting()
+
+    connection_close.assert_awaited_once_with()
+
+
+async def test_stale_connection_failure_does_not_clear_new_connection() -> None:
+    first_connection = BaseMockConnection()
+    second_connection = BaseMockConnection()
+    first_state = ActiveConnectionState(
+        connection=first_connection,
+        lifespan=mock.Mock(),
+        server_heartbeat=build_dataclass(Heartbeat),
+        connected_at=time.time(),
+    )
+    second_state = ActiveConnectionState(
+        connection=second_connection,
+        lifespan=mock.Mock(),
+        server_heartbeat=build_dataclass(Heartbeat),
+        connected_at=time.time(),
+    )
+    manager = EnrichedConnectionManager(connection_class=BaseMockConnection)
+    manager._active_connection_state = second_state
+
+    await manager._discard_failed_connection_state(first_state, build_dataclass(ConnectionLostError))
+
+    assert manager._active_connection_state is second_state
+    assert manager._reconnection_count == 0
+
+
+async def test_heartbeat_failure_is_fatal_by_default() -> None:
+    class MockConnection(BaseMockConnection):
+        write_heartbeat = mock.Mock(side_effect=build_dataclass(ConnectionLostError))
+
+    manager = EnrichedConnectionManager(connection_class=MockConnection, write_retry_attempts=1)
+
+    with pytest.raises(FailedAllWriteAttemptsError):
+        await manager._send_heartbeats_forever(send_heartbeat_interval_ms=1)
+
+
+async def test_heartbeat_failure_keeps_manager_alive_when_enabled() -> None:
+    expected_minimum_heartbeat_attempts = 2
+    heartbeat_recovered = asyncio.Event()
+    heartbeat_attempts = 0
+
+    class MockConnection(BaseMockConnection):
+        async def close(self) -> None:
+            return None
+
+        def write_heartbeat(self) -> None:
+            nonlocal heartbeat_attempts
+            heartbeat_attempts += 1
+            if heartbeat_attempts == 1:
+                raise build_dataclass(ConnectionLostError)
+            heartbeat_recovered.set()
+
+    manager = EnrichedConnectionManager(
+        connection_class=MockConnection,
+        write_retry_attempts=1,
+        keep_alive_on_connection_failure=True,
+    )
+    heartbeat_task = asyncio.create_task(manager._send_heartbeats_forever(send_heartbeat_interval_ms=1))
+
+    await asyncio.wait_for(heartbeat_recovered.wait(), timeout=1)
+
+    assert not heartbeat_task.done()
+    assert heartbeat_attempts >= expected_minimum_heartbeat_attempts
+    heartbeat_task.cancel()
+    await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+
+async def test_read_reconnect_exhaustion_keeps_manager_alive_when_enabled() -> None:
+    expected_connect_attempts = 2
+    connect_attempts = 0
+
+    class MockConnection(BaseMockConnection):
+        @classmethod
+        async def connect(
+            cls,
+            *,
+            host: str,
+            port: int,
+            timeout: int,
+            read_max_chunk_size: int,
+            ssl: Literal[True] | SSLContext | None,
+            ws_uri_path: str | None = None,
+        ) -> Self | None:
+            del host, port, timeout, read_max_chunk_size, ssl, ws_uri_path
+            nonlocal connect_attempts
+            connect_attempts += 1
+            return None if connect_attempts == 1 else cls()
+
+        @staticmethod
+        async def read_frames() -> AsyncGenerator[AnyServerFrame, None]:
+            yield build_dataclass(ConnectedFrame)
+
+    manager = EnrichedConnectionManager(
+        connection_class=MockConnection,
+        connect_retry_attempts=1,
+        keep_alive_on_connection_failure=True,
+    )
+
+    frame, epoch = await anext(manager.read_frames_reconnecting())
+
+    assert isinstance(frame, ConnectedFrame)
+    assert epoch == 0
+    assert connect_attempts == expected_connect_attempts
+
+
 async def test_write_frame_reconnecting_raises() -> None:
+    connection_close = mock.AsyncMock()
     write_frame_mock = mock.AsyncMock(
         side_effect=[
             build_dataclass(ConnectionLostError),
@@ -286,12 +443,39 @@ async def test_write_frame_reconnecting_raises() -> None:
     )
 
     class MockConnection(BaseMockConnection):
+        close = connection_close
         write_frame = write_frame_mock
 
     manager = EnrichedConnectionManager(connection_class=MockConnection)
 
     with pytest.raises(FailedAllWriteAttemptsError):
         await manager.write_frame_reconnecting(build_dataclass(ConnectFrame))
+
+    assert connection_close.await_count == manager.write_retry_attempts
+
+
+async def test_read_frames_reconnecting_closes_failed_connection() -> None:
+    connection_close = mock.AsyncMock()
+    read_attempts = 0
+
+    class MockConnection(BaseMockConnection):
+        close = connection_close
+
+        @staticmethod
+        async def read_frames() -> AsyncGenerator[AnyServerFrame, None]:
+            nonlocal read_attempts
+            read_attempts += 1
+            if read_attempts == 1:
+                raise build_dataclass(ConnectionLostError)
+            yield build_dataclass(ConnectedFrame)
+
+    manager = EnrichedConnectionManager(connection_class=MockConnection)
+
+    frame, epoch = await anext(manager.read_frames_reconnecting())
+
+    assert isinstance(frame, ConnectedFrame)
+    assert epoch == 1
+    connection_close.assert_awaited_once_with()
 
 
 SIDE_EFFECTS = [

--- a/packages/stompman/test_stompman/test_integration.py
+++ b/packages/stompman/test_stompman/test_integration.py
@@ -26,15 +26,17 @@ async def wait_for_reconnect(client: stompman.Client, initial_reconnection_count
             and client._connection_manager._active_connection_state is not None
         )
 
-    while not is_reconnected():  # noqa: ASYNC110
+    while not is_reconnected():  # ruff: ignore[async-busy-wait]
         await asyncio.sleep(0.05)
 
 
 async def force_reconnect(client: stompman.Client) -> None:
     connection_state = await client._connection_manager._get_active_connection_state()
     initial_reconnection_count = client._connection_manager._reconnection_count
-    client._connection_manager._clear_active_connection_state(stompman.ConnectionLostError(reason="test reconnect"))
-    await connection_state.connection.close()
+    await client._connection_manager._discard_failed_connection_state(
+        connection_state,
+        stompman.ConnectionLostError(reason="test reconnect"),
+    )
     await asyncio.wait_for(wait_for_reconnect(client, initial_reconnection_count), timeout=5)
 
 
@@ -101,7 +103,7 @@ async def test_ok(connection_parameters: stompman.ConnectionParameters) -> None:
         received_messages: list[bytes] = []
         event = asyncio.Event()
 
-        async def handle_message(frame: stompman.MessageFrame) -> None:  # noqa: RUF029
+        async def handle_message(frame: stompman.MessageFrame) -> None:  # ruff: ignore[unused-async]
             received_messages.append(frame.body)
             if len(received_messages) == len(messages):
                 event.set()

--- a/packages/stompman/test_stompman/test_subscription.py
+++ b/packages/stompman/test_stompman/test_subscription.py
@@ -12,7 +12,6 @@ from stompman import (
     AckFrame,
     AckMode,
     ConnectedFrame,
-    ConnectionLostError,
     ErrorFrame,
     FailedAllConnectAttemptsError,
     HeartbeatFrame,
@@ -32,6 +31,7 @@ from test_stompman.conftest import (
     SomeError,
     build_dataclass,
     create_spying_connection,
+    drop_active_connection,
     enrich_expected_frames,
     get_read_frames_with_lifespan,
     noop_error_handler,
@@ -56,7 +56,7 @@ async def test_client_subscriptions_lifespan_resubscribe(ack: AckMode, faker: fa
             headers=sub_extra_headers,
             on_suppressed_exception=noop_error_handler,
         )
-        client._connection_manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
+        await drop_active_connection(client)
         await client.send(message_body, destination=message_destination)
         await subscription.unsubscribe()
         await asyncio.sleep(0)
@@ -124,14 +124,14 @@ async def test_client_subscriptions_lifespan_with_active_subs_in_aexit(
     connection_class, collected_frames = create_spying_connection(*get_read_frames_with_lifespan([]))
 
     if direct_error:
-        with pytest.raises(SomeError):  # noqa: PT012
+        with pytest.raises(SomeError):  # ruff: ignore[pytest-raises-with-multiple-statements]
             async with EnrichedClient(connection_class=connection_class) as client:
                 await client.subscribe(
                     destination, handler=noop_message_handler, on_suppressed_exception=noop_error_handler
                 )
                 await SomeError.raise_after_tick()
     else:
-        with pytest.raises(ExceptionGroup) as exc_info:  # noqa: PT012
+        with pytest.raises(ExceptionGroup) as exc_info:  # ruff: ignore[pytest-raises-with-multiple-statements]
             async with asyncio.TaskGroup() as task_group, EnrichedClient(connection_class=connection_class) as client:
                 await client.subscribe(
                     destination, handler=noop_message_handler, on_suppressed_exception=noop_error_handler
@@ -356,9 +356,9 @@ async def test_client_listen_raises_on_aexit(monkeypatch: pytest.MonkeyPatch, fa
 
     async def close_connection_soon(client: stompman.Client) -> None:
         await asyncio.sleep(0)
-        client._connection_manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
+        await drop_active_connection(client)
 
-    with pytest.raises(ExceptionGroup) as exc_info:  # noqa: PT012
+    with pytest.raises(ExceptionGroup) as exc_info:  # ruff: ignore[pytest-raises-with-multiple-statements]
         async with asyncio.TaskGroup() as task_group, EnrichedClient(connection_class=connection_class) as client:
             await client.subscribe(faker.pystr(), noop_message_handler, on_suppressed_exception=noop_error_handler)
             task_group.create_task(close_connection_soon(client))
@@ -389,7 +389,7 @@ async def test_subscription_sends_ack_for_message_received_after_reconnection(
 
     async with EnrichedClient(connection_class=connection_class) as client:
         subscription = await client.subscribe_with_manual_ack(destination, noop_message_handler)
-        client._connection_manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
+        await drop_active_connection(client)
         await client.send(b"trigger-reconnect", destination=destination)
         message_after_reconnect = stompman.subscription.AckableMessageFrame(
             headers=message_frame.headers,
@@ -432,7 +432,7 @@ async def test_subscription_skips_ack_nack_after_reconnection(
     async with EnrichedClient(connection_class=connection_class) as client:
         subscription = await client.subscribe_with_manual_ack(destination, track_ack_nack_frames)
         await asyncio.sleep(0)
-        client._connection_manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
+        await drop_active_connection(client)
         await asyncio.sleep(0)
 
         with caplog.at_level(logging.WARNING, logger="stompman"):
@@ -472,7 +472,7 @@ async def test_subscription_skips_ack_for_message_consumed_after_concurrent_clea
     next_connection_id = 0
     listener_read_call_index: Final = 2
 
-    async def store_message_handler(message: stompman.subscription.AckableMessageFrame) -> None:  # noqa: RUF029
+    async def store_message_handler(message: stompman.subscription.AckableMessageFrame) -> None:  # ruff: ignore[unused-async]
         received_messages.append(message)
 
     class GatedConnection(BaseMockConnection):
@@ -508,7 +508,7 @@ async def test_subscription_skips_ack_for_message_consumed_after_concurrent_clea
     async with EnrichedClient(connection_class=GatedConnection) as client:
         subscription = await client.subscribe_with_manual_ack(destination, store_message_handler)
         await asyncio.sleep(0)
-        client._connection_manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
+        await drop_active_connection(client)
         assert client._connection_manager._reconnection_count == 1
         await client.send(b"trigger-reconnect", destination=destination)
         assert client._connection_manager._active_connection_state is not None
@@ -553,7 +553,7 @@ async def test_auto_ack_handler_unhandled_exception_does_not_kill_listener(
 
     expected_handled = 2
 
-    async def handler(frame: MessageFrame) -> None:  # noqa: RUF029
+    async def handler(frame: MessageFrame) -> None:  # ruff: ignore[unused-async]
         handled.append(frame.headers["message-id"])
         if frame.headers["message-id"] == "a":
             raise BoomError
@@ -598,7 +598,7 @@ async def test_manual_ack_handler_unhandled_exception_does_not_kill_listener(
     handled: list[str] = []
     expected_handled = 2
 
-    async def handler(frame: stompman.subscription.AckableMessageFrame) -> None:  # noqa: RUF029
+    async def handler(frame: stompman.subscription.AckableMessageFrame) -> None:  # ruff: ignore[unused-async]
         handled.append(frame.headers["message-id"])
         if frame.headers["message-id"] == "a":
             msg = "boom"

--- a/packages/stompman/test_stompman/test_transaction.py
+++ b/packages/stompman/test_stompman/test_transaction.py
@@ -12,15 +12,14 @@ from stompman import (
     CommitFrame,
     SendFrame,
 )
-from stompman.errors import ConnectionLostError
 
 from test_stompman.conftest import (
     CONNECT_FRAME,
     CONNECTED_FRAME,
     EnrichedClient,
     SomeError,
-    build_dataclass,
     create_spying_connection,
+    drop_active_connection,
     enrich_expected_frames,
     get_read_frames_with_lifespan,
 )
@@ -87,7 +86,7 @@ async def test_commit_pending_transactions(monkeypatch: pytest.MonkeyPatch, fake
     async with EnrichedClient(connection_class=connection_class) as client:
         async with client.begin() as first_transaction:
             await first_transaction.send(body, destination=destination)
-            client._connection_manager._clear_active_connection_state(build_dataclass(ConnectionLostError))
+            await drop_active_connection(client)
         async with client.begin() as second_transaction:
             await second_transaction.send(body, destination=destination)
         await asyncio.sleep(0)


### PR DESCRIPTION
## Summary

- add opt-in `keep_alive_on_connection_failure` behavior to `stompman.Client`
- keep background heartbeat and read recovery alive after a retry cycle is exhausted
- detach and close failed connections without allowing stale failures to clear a newer connection
- preserve the existing fail-fast default used by FastStream

`Client.send()` keeps its finite connect/write retry budget and still raises after exhaustion, so ambiguous `SEND` frames are not retried indefinitely.

Related to #128.

## Validation

- `just lint`
- `just check-types` — 49 source files
- `just test-fast` — 260 passed, 1 skipped
- `just test` — 309 passed, 1 skipped, including Artemis, ActiveMQ Classic, and FastStream integration tests
