### PR TITLE
Expose content-length controls in faststream-stomp

### DIFF
--- a/packages/faststream-stomp/README.md
+++ b/packages/faststream-stomp/README.md
@@ -49,6 +49,21 @@ if __name__ == "__main__":
 
 Also there are `StompRouter` and `TestStompBroker` for testing. It works similarly to built-in brokers from FastStream, I recommend to read the original [FastStream documentation](https://faststream.airt.ai/latest/getting-started).
 
+By default, published frames include the STOMP `content-length` header. You can change this for the whole broker or
+override it for a publisher or individual publish call:
+
+```python
+broker = faststream_stomp.StompBroker(stompman.Client([server]), add_content_length=False)
+publisher = broker.publisher("events", add_content_length=True)
+
+await broker.publish("text message", "events", add_content_length=False)
+await publisher.publish("bytes message")
+```
+
+Use `reply_add_content_length` on `subscriber()` when automatic replies need a different setting. The same options
+are available for batch publishing and delayed `StompRoute`/`StompRoutePublisher` registrations. Per-call settings
+override publisher or subscriber reply defaults, which in turn override the broker default.
+
 ### Caveats
 
 - When exception is raised in consumer handler, the message will be nacked (FastStream doesn't do this by default)

--- a/packages/faststream-stomp/faststream_stomp/broker.py
+++ b/packages/faststream-stomp/faststream_stomp/broker.py
@@ -101,6 +101,7 @@ class StompBroker(
         middlewares: Sequence[type[BaseMiddleware] | BrokerMiddleware[stompman.MessageFrame, StompPublishCommand]] = (),
         graceful_timeout: float | None = 15.0,
         routers: Sequence[Registrator[stompman.MessageFrame]] = (),
+        add_content_length: bool = True,
         # Logging args
         logger: LoggerProto | None = EMPTY,
         log_level: int = logging.INFO,
@@ -124,7 +125,11 @@ class StompBroker(
             broker_dependencies=dependencies,
             graceful_timeout=graceful_timeout,
             extra_context={"broker": self},
-            producer=StompProducer(client=client, serializer=fd_config._serializer),
+            producer=StompProducer(
+                client=client,
+                serializer=fd_config._serializer,
+                add_content_length=add_content_length,
+            ),
             client=client,
         )
         specification = BrokerSpec(
@@ -193,6 +198,7 @@ class StompBroker(
         *,
         correlation_id: str | None = None,
         headers: dict[str, str] | None = None,
+        add_content_length: bool | None = None,
     ) -> None:
         publish_command = StompPublishCommand(
             message,
@@ -200,6 +206,7 @@ class StompBroker(
             destination=destination,
             correlation_id=correlation_id,
             headers=headers,
+            add_content_length=add_content_length,
         )
         return typing.cast("None", await self._basic_publish(publish_command, producer=self.config.producer))
 
@@ -210,6 +217,7 @@ class StompBroker(
         *,
         correlation_id: str | None = None,
         headers: dict[str, str] | None = None,
+        add_content_length: bool | None = None,
     ) -> Any:  # noqa: ANN401
         publish_command = StompPublishCommand(
             message,
@@ -217,6 +225,7 @@ class StompBroker(
             destination=destination,
             correlation_id=correlation_id,
             headers=headers,
+            add_content_length=add_content_length,
         )
         return await self._basic_request(publish_command, producer=self.config.producer)
 
@@ -226,6 +235,7 @@ class StompBroker(
         destination: str,
         correlation_id: str | None = None,
         headers: dict[str, str] | None = None,
+        add_content_length: bool | None = None,
     ) -> None:
         publish_command = StompPublishCommand(
             *messages,
@@ -233,5 +243,6 @@ class StompBroker(
             destination=destination,
             correlation_id=correlation_id,
             headers=headers,
+            add_content_length=add_content_length,
         )
         return typing.cast("None", await self._basic_publish_batch(publish_command, producer=self.config.producer))

--- a/packages/faststream-stomp/faststream_stomp/models.py
+++ b/packages/faststream-stomp/faststream_stomp/models.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
-from typing import Self, cast
+from typing import Any, Self, cast
 
 import stompman
-from faststream import AckPolicy, BatchPublishCommand, PublishCommand, StreamMessage
+from faststream import AckPolicy, BatchPublishCommand, PublishCommand, PublishType, StreamMessage
+from faststream._internal.basic_types import SendableMessage
 from faststream._internal.configs import (
     BrokerConfig,
     PublisherSpecificationConfig,
@@ -44,9 +45,40 @@ class StompStreamMessage(StreamMessage[stompman.AckableMessageFrame]):
 
 
 class StompPublishCommand(BatchPublishCommand):
+    def __init__(
+        self,
+        body: SendableMessage,
+        /,
+        *bodies: SendableMessage,
+        _publish_type: PublishType,
+        reply_to: str = "",
+        destination: str = "",
+        correlation_id: str | None = None,
+        headers: dict[str, Any] | None = None,
+        add_content_length: bool | None = None,
+    ) -> None:
+        super().__init__(
+            body,
+            *bodies,
+            _publish_type=_publish_type,
+            reply_to=reply_to,
+            destination=destination,
+            correlation_id=correlation_id,
+            headers=headers,
+        )
+        self.add_content_length = add_content_length
+
     @classmethod
-    def from_cmd(cls, cmd: PublishCommand, *, batch: bool = False) -> Self:  # noqa: ARG003
+    def from_cmd(
+        cls,
+        cmd: PublishCommand,
+        *,
+        batch: bool = False,  # noqa: ARG003
+        add_content_length: bool | None = None,
+    ) -> Self:
         messages = cmd.batch_bodies
+        if isinstance(cmd, StompPublishCommand) and cmd.add_content_length is not None:
+            add_content_length = cmd.add_content_length
         return cls(
             *messages,
             _publish_type=cmd.publish_type,
@@ -54,6 +86,7 @@ class StompPublishCommand(BatchPublishCommand):
             destination=cmd.destination,
             correlation_id=cmd.correlation_id,
             headers=cmd.headers,
+            add_content_length=add_content_length,
         )
 
 
@@ -78,6 +111,7 @@ class StompSubscriberSpecificationConfig(_StompBaseSubscriberConfig, SubscriberS
 @dataclass(kw_only=True)
 class StompSubscriberUsecaseConfig(_StompBaseSubscriberConfig, SubscriberUsecaseConfig):
     _outer_config: BrokerConfigWithStompClient
+    reply_add_content_length: bool | None
     parser: AsyncCallable = StompStreamMessage.from_frame
     decoder: AsyncCallable = field(default=to_async(decode_message))
 
@@ -102,6 +136,7 @@ class StompPublisherSpecificationConfig(_StompBasePublisherConfig, PublisherSpec
 @dataclass(kw_only=True)
 class StompPublisherUsecaseConfig(_StompBasePublisherConfig, PublisherUsecaseConfig):
     _outer_config: BrokerConfigWithStompClient
+    add_content_length: bool | None
 
     @property
     def full_destination(self) -> str:

--- a/packages/faststream-stomp/faststream_stomp/publisher.py
+++ b/packages/faststream-stomp/faststream_stomp/publisher.py
@@ -25,14 +25,27 @@ class StompProducer(ProducerProto[StompPublishCommand]):
     _parser: AsyncCallable
     _decoder: AsyncCallable
 
-    def __init__(self, *, client: stompman.Client, serializer: SerializerProto | None) -> None:
+    def __init__(
+        self,
+        *,
+        client: stompman.Client,
+        serializer: SerializerProto | None,
+        add_content_length: bool = True,
+    ) -> None:
         self.client = client
         self.serializer = serializer
+        self.add_content_length = add_content_length
         self.codec: CodecProto = DefaultCodec()
 
     async def publish(self, cmd: StompPublishCommand) -> None:
         body, content_type = encode_message(cmd.body, serializer=self.serializer)
-        await self.client.send(body, cmd.destination, content_type=content_type, headers=_make_headers_for_publish(cmd))
+        await self.client.send(
+            body,
+            cmd.destination,
+            content_type=content_type,
+            add_content_length=self._resolve_add_content_length(cmd),
+            headers=_make_headers_for_publish(cmd),
+        )
 
     async def request(self, cmd: StompPublishCommand) -> NoReturn:
         msg = "`StompProducer` can be used only to publish a response for `reply-to` or `RPC` messages."
@@ -43,8 +56,15 @@ class StompProducer(ProducerProto[StompPublishCommand]):
             for one_body in cmd.batch_bodies:
                 body, content_type = encode_message(one_body, serializer=self.serializer)
                 await transaction.send(
-                    body, cmd.destination, content_type=content_type, headers=_make_headers_for_publish(cmd)
+                    body,
+                    cmd.destination,
+                    content_type=content_type,
+                    add_content_length=self._resolve_add_content_length(cmd),
+                    headers=_make_headers_for_publish(cmd),
                 )
+
+    def _resolve_add_content_length(self, cmd: StompPublishCommand) -> bool:
+        return self.add_content_length if cmd.add_content_length is None else cmd.add_content_length
 
 
 def _make_headers_for_publish(cmd: StompPublishCommand) -> dict[str, str]:
@@ -82,7 +102,7 @@ class StompPublisher(PublisherUsecase):
     async def _publish(
         self, cmd: PublishCommand, *, _extra_middlewares: typing.Iterable[PublisherMiddleware[PublishCommand]]
     ) -> None:
-        publish_command = StompPublishCommand.from_cmd(cmd)
+        publish_command = StompPublishCommand.from_cmd(cmd, add_content_length=self.config.add_content_length)
         publish_command.destination = self.config.full_destination
         return typing.cast(
             "None",
@@ -92,7 +112,12 @@ class StompPublisher(PublisherUsecase):
         )
 
     async def publish(
-        self, message: SendableMessage, *, correlation_id: str | None = None, headers: dict[str, str] | None = None
+        self,
+        message: SendableMessage,
+        *,
+        correlation_id: str | None = None,
+        headers: dict[str, str] | None = None,
+        add_content_length: bool | None = None,
     ) -> None:
         publish_command = StompPublishCommand(
             message,
@@ -100,6 +125,7 @@ class StompPublisher(PublisherUsecase):
             destination=self.config.full_destination,
             correlation_id=correlation_id,
             headers=headers,
+            add_content_length=self.config.add_content_length if add_content_length is None else add_content_length,
         )
         return typing.cast(
             "None",
@@ -109,7 +135,12 @@ class StompPublisher(PublisherUsecase):
         )
 
     async def request(
-        self, message: SendableMessage, *, correlation_id: str | None = None, headers: dict[str, str] | None = None
+        self,
+        message: SendableMessage,
+        *,
+        correlation_id: str | None = None,
+        headers: dict[str, str] | None = None,
+        add_content_length: bool | None = None,
     ) -> Any:  # noqa: ANN401
         publish_command = StompPublishCommand(
             message,
@@ -117,11 +148,16 @@ class StompPublisher(PublisherUsecase):
             destination=self.config.full_destination,
             correlation_id=correlation_id,
             headers=headers,
+            add_content_length=self.config.add_content_length if add_content_length is None else add_content_length,
         )
         return await self._basic_request(publish_command, producer=self.config._outer_config.producer)
 
     async def publish_batch(
-        self, *messages: SendableMessage, correlation_id: str | None = None, headers: dict[str, str] | None = None
+        self,
+        *messages: SendableMessage,
+        correlation_id: str | None = None,
+        headers: dict[str, str] | None = None,
+        add_content_length: bool | None = None,
     ) -> None:
         publish_command = StompPublishCommand(
             *messages,
@@ -129,6 +165,7 @@ class StompPublisher(PublisherUsecase):
             destination=self.config.full_destination,
             correlation_id=correlation_id,
             headers=headers,
+            add_content_length=self.config.add_content_length if add_content_length is None else add_content_length,
         )
         return typing.cast(
             "None",

--- a/packages/faststream-stomp/faststream_stomp/registrator.py
+++ b/packages/faststream-stomp/faststream_stomp/registrator.py
@@ -27,6 +27,7 @@ class StompRegistrator(Registrator[stompman.MessageFrame, BrokerConfigWithStompC
         *,
         ack_mode: stompman.AckMode = "client-individual",
         headers: dict[str, str] | None = None,
+        reply_add_content_length: bool | None = None,
         # other args
         dependencies: Iterable[Dependant] = (),
         parser: CustomCallable | None = None,
@@ -40,6 +41,7 @@ class StompRegistrator(Registrator[stompman.MessageFrame, BrokerConfigWithStompC
             destination_without_prefix=destination,
             ack_mode=ack_mode,
             headers=headers,
+            reply_add_content_length=reply_add_content_length,
         )
         calls = CallsCollection[stompman.MessageFrame]()
         specification = StompSubscriberSpecification(
@@ -71,10 +73,12 @@ class StompRegistrator(Registrator[stompman.MessageFrame, BrokerConfigWithStompC
         title_: str | None = None,
         description_: str | None = None,
         include_in_schema: bool = True,
+        add_content_length: bool | None = None,
     ) -> StompPublisher:
         usecase_config = StompPublisherUsecaseConfig(
             _outer_config=self.config,  # type: ignore[arg-type]
             destination_without_prefix=destination,
+            add_content_length=add_content_length,
         )
         specification = StompPublisherSpecification(
             _outer_config=self.config,  # type: ignore[arg-type]

--- a/packages/faststream-stomp/faststream_stomp/router.py
+++ b/packages/faststream-stomp/faststream_stomp/router.py
@@ -25,6 +25,7 @@ class StompRoutePublisher(ArgsContainer):
         title_: str | None = None,
         description_: str | None = None,
         include_in_schema: bool = True,
+        add_content_length: bool | None = None,
     ) -> None:
         super().__init__(
             destination=destination,
@@ -32,6 +33,7 @@ class StompRoutePublisher(ArgsContainer):
             title_=title_,
             description_=description_,
             include_in_schema=include_in_schema,
+            add_content_length=add_content_length,
         )
 
 
@@ -48,6 +50,7 @@ class StompRoute(SubscriberRoute):
         *,
         ack_mode: stompman.AckMode = "client-individual",
         headers: dict[str, str] | None = None,
+        reply_add_content_length: bool | None = None,
         # other args
         publishers: Iterable[StompRoutePublisher] = (),
         dependencies: Iterable[Dependant] = (),
@@ -62,6 +65,7 @@ class StompRoute(SubscriberRoute):
             destination=destination,
             ack_mode=ack_mode,
             headers=headers,
+            reply_add_content_length=reply_add_content_length,
             publishers=publishers,
             dependencies=dependencies,
             parser=parser,

--- a/packages/faststream-stomp/faststream_stomp/subscriber.py
+++ b/packages/faststream-stomp/faststream_stomp/subscriber.py
@@ -38,13 +38,20 @@ class StompSubscriberSpecification(SubscriberSpecification[BrokerConfig, StompSu
 
 
 class StompFakePublisher(FakePublisher):
-    def __init__(self, *, producer: ProducerProto[Any], reply_to: str) -> None:
+    def __init__(
+        self,
+        *,
+        producer: ProducerProto[Any],
+        reply_to: str,
+        add_content_length: bool | None,
+    ) -> None:
         super().__init__(producer=producer)
         self.reply_to = reply_to
+        self.add_content_length = add_content_length
 
     def patch_command(self, cmd: PublishCommand | StompPublishCommand) -> StompPublishCommand:
         cmd = super().patch_command(cmd)
-        real_cmd = StompPublishCommand.from_cmd(cmd)
+        real_cmd = StompPublishCommand.from_cmd(cmd, add_content_length=self.add_content_length)
         real_cmd.destination = self.reply_to
         return real_cmd
 
@@ -85,7 +92,13 @@ class StompSubscriber(SubscriberUsecase[stompman.MessageFrame]):
         await asyncio.sleep(0)  # pragma: no cover
 
     def _make_response_publisher(self, message: StreamMessage[stompman.MessageFrame]) -> Sequence[FakePublisher]:
-        return (StompFakePublisher(producer=self.config._outer_config.producer, reply_to=message.reply_to),)
+        return (
+            StompFakePublisher(
+                producer=self.config._outer_config.producer,
+                reply_to=message.reply_to,
+                add_content_length=self.config.reply_add_content_length,
+            ),
+        )
 
     def get_log_context(self, message: StreamMessage[stompman.MessageFrame] | None) -> dict[str, str]:
         return {

--- a/packages/faststream-stomp/faststream_stomp/testing.py
+++ b/packages/faststream-stomp/faststream_stomp/testing.py
@@ -66,6 +66,7 @@ class FakeAckableMessageFrame(stompman.AckableMessageFrame):
 class FakeStompProducer(StompProducer):
     def __init__(self, broker: StompBroker) -> None:
         self.broker = broker
+        self.add_content_length = typing.cast("StompProducer", broker.config.producer).add_content_length
         self.codec = DefaultCodec()
 
     async def publish(self, cmd: StompPublishCommand) -> None:
@@ -85,7 +86,7 @@ class FakeStompProducer(StompProducer):
                 destination=cmd.destination,
                 transaction=None,
                 content_type=content_type,
-                add_content_length=False,
+                add_content_length=self._resolve_add_content_length(cmd),
                 headers=cmd.headers,
             )
         )

--- a/packages/faststream-stomp/test_faststream_stomp/test_main.py
+++ b/packages/faststream-stomp/test_faststream_stomp/test_main.py
@@ -2,13 +2,14 @@ import asyncio
 import contextlib
 import logging
 import typing
+from unittest import mock
 
 import faker
 import faststream_stomp
 import pydantic
 import pytest
 import stompman
-from faststream import FastStream
+from faststream import FastStream, PublishCommand, PublishType
 from faststream.message import gen_cor_id
 from faststream_stomp.broker import _handle_listen_task_done
 from faststream_stomp.opentelemetry import StompTelemetryMiddleware
@@ -19,6 +20,9 @@ from opentelemetry.sdk.trace import TracerProvider
 from polyfactory.factories.pydantic_factory import ModelFactory
 from prometheus_client import CollectorRegistry
 from test_stompman.conftest import build_dataclass
+
+if typing.TYPE_CHECKING:
+    from faststream_stomp.subscriber import StompFakePublisher
 
 pytestmark = pytest.mark.anyio
 
@@ -31,6 +35,14 @@ def fake_connection_params() -> stompman.ConnectionParameters:
 @pytest.fixture
 def broker(fake_connection_params: stompman.ConnectionParameters) -> faststream_stomp.StompBroker:
     return faststream_stomp.StompBroker(stompman.Client([fake_connection_params]))
+
+
+def make_mock_client(
+    connection_parameters: stompman.ConnectionParameters,
+) -> tuple[stompman.Client, mock.NonCallableMagicMock]:
+    client_mock = mock.create_autospec(stompman.Client, instance=True)
+    client_mock.servers = [connection_parameters]
+    return typing.cast("stompman.Client", client_mock), client_mock
 
 
 class TestTesting:
@@ -131,6 +143,103 @@ class TestNotImplemented:
             with pytest.raises(NotImplementedError):
                 async for _ in broker.subscriber(faker.pystr()):
                     ...  # pragma: no cover
+
+
+class TestAddContentLength:
+    @pytest.mark.parametrize(
+        ("broker_default", "call_override", "expected"),
+        [
+            (True, None, True),
+            (False, None, False),
+            (False, True, True),
+            (True, False, False),
+        ],
+    )
+    async def test_broker_publish(
+        self,
+        fake_connection_params: stompman.ConnectionParameters,
+        faker: faker.Faker,
+        *,
+        broker_default: bool,
+        call_override: bool | None,
+        expected: bool,
+    ) -> None:
+        client, client_mock = make_mock_client(fake_connection_params)
+        broker = faststream_stomp.StompBroker(client, add_content_length=broker_default)
+
+        await broker.publish(faker.pystr(), faker.pystr(), add_content_length=call_override)
+
+        assert client_mock.send.await_args.kwargs["add_content_length"] is expected
+
+    @pytest.mark.parametrize(
+        ("broker_default", "publisher_default", "call_override", "expected"),
+        [
+            (True, None, None, True),
+            (False, None, None, False),
+            (True, False, None, False),
+            (False, True, None, True),
+            (True, True, False, False),
+            (False, False, True, True),
+        ],
+    )
+    async def test_publisher_publish(
+        self,
+        fake_connection_params: stompman.ConnectionParameters,
+        faker: faker.Faker,
+        *,
+        broker_default: bool,
+        publisher_default: bool | None,
+        call_override: bool | None,
+        expected: bool,
+    ) -> None:
+        client, client_mock = make_mock_client(fake_connection_params)
+        broker = faststream_stomp.StompBroker(client, add_content_length=broker_default)
+        publisher = broker.publisher(faker.pystr(), add_content_length=publisher_default)
+
+        await publisher.publish(faker.pystr(), add_content_length=call_override)
+
+        assert client_mock.send.await_args.kwargs["add_content_length"] is expected
+
+    async def test_publish_batch(
+        self, fake_connection_params: stompman.ConnectionParameters, faker: faker.Faker
+    ) -> None:
+        client, client_mock = make_mock_client(fake_connection_params)
+        broker = faststream_stomp.StompBroker(client)
+        transaction = mock.AsyncMock()
+        messages = (faker.pystr(), faker.pystr())
+
+        client_mock.begin.return_value.__aenter__.return_value = transaction
+        await broker.publish_batch(
+            *messages,
+            destination=faker.pystr(),
+            add_content_length=False,
+        )
+
+        assert transaction.send.await_count == len(messages)
+        assert all(call.kwargs["add_content_length"] is False for call in transaction.send.await_args_list)
+
+    async def test_publisher_decorator_default(self, broker: faststream_stomp.StompBroker, faker: faker.Faker) -> None:
+        publisher = broker.publisher(faker.pystr(), add_content_length=False)
+        publish_mock = mock.AsyncMock()
+        command = PublishCommand(faker.pystr(), _publish_type=PublishType.PUBLISH)
+
+        with mock.patch.object(broker.config.producer, "publish", publish_mock):
+            await publisher._publish(command, _extra_middlewares=())
+
+        assert publish_mock.await_args is not None
+        published_command = publish_mock.await_args.args[0]
+        assert published_command.add_content_length is False
+
+    def test_subscriber_reply_default(self, broker: faststream_stomp.StompBroker, faker: faker.Faker) -> None:
+        subscriber = broker.subscriber(faker.pystr(), reply_add_content_length=False)
+        response_publisher = typing.cast(
+            "StompFakePublisher",
+            subscriber._make_response_publisher(mock.Mock(reply_to=faker.pystr()))[0],
+        )
+
+        command = response_publisher.patch_command(PublishCommand(faker.pystr(), _publish_type=PublishType.REPLY))
+
+        assert command.add_content_length is False
 
 
 def test_asyncapi_schema(faker: faker.Faker, broker: faststream_stomp.StompBroker) -> None:

--- a/packages/faststream-stomp/test_faststream_stomp/test_typing.py
+++ b/packages/faststream-stomp/test_faststream_stomp/test_typing.py
@@ -17,3 +17,13 @@ if typing.TYPE_CHECKING:
         ),
     )
     app = faststream.FastStream(broker)
+
+    async def check_add_content_length_typing() -> None:
+        await broker.publish("message", "destination", add_content_length=False)
+        await broker.publish_batch("first", "second", destination="destination", add_content_length=False)
+
+        publisher = broker.publisher("destination", add_content_length=False)
+        await publisher.publish("message", add_content_length=True)
+        await publisher.publish_batch("first", "second", add_content_length=True)
+
+        broker.subscriber("destination", reply_add_content_length=False)


### PR DESCRIPTION
## Summary

- add a broker-wide default for STOMP content-length emission
- allow publisher and individual publish-call overrides
- propagate the setting through batch publishing and subscriber replies
- preserve the existing enabled-by-default behavior

## Motivation

Some STOMP brokers use the presence of the content-length header when mapping frames to broker-native message types. stompman already supports controlling that header, so faststream-stomp should expose the same capability without requiring callers to bypass the broker abstraction.

## Verification

- just test -q
- just check-types
- just lint
- git diff --check