### PR TITLE
Add opt-in receipt-confirmed subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ that connection; it does not remove previously confirmed subscriptions.
 Neither subscription confirmation nor a publish receipt proves downstream
 business processing.
 
+The handler concurrency limit remains in effect while confirmations are
+pending. The reader temporarily buffers message handlers waiting for capacity
+so it can reach interleaved receipts/errors, then resumes normal backpressure.
+Use broker prefetch/consumer-window settings to bound deliveries on the wire.
+
 ### Cleaning Up
 
 stompman takes care of cleaning up resources automatically. When you leave the context of async context managers `stompman.Client()`, or `client.begin()`, the necessary frames will be sent to the server.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,45 @@ await client.subscribe_with_manual_ack("DLQ", handle_message_from_dlq, ack="clie
 
 Note that this way exceptions won't be suppressed automatically.
 
+#### Confirming subscriptions
+
+Pass `receipt_timeout` to either subscription method to wait for the broker to
+accept the subscription before returning. This uses standard
+[STOMP receipts](https://stomp.github.io/stomp-specification-1.2.html#RECEIPT),
+not broker-specific error messages.
+
+```python
+subscription = await client.subscribe_with_manual_ack(
+    "DLQ",
+    handle_message_from_dlq,
+    receipt_timeout=3.0,
+    on_subscription_error=lambda error: print(error.reason),
+)
+# It is now safe to publish a request that requires this response subscription.
+```
+
+The default `receipt_timeout=None` preserves the existing write-only behavior.
+A timeout must be finite and positive. It covers writing `SUBSCRIBE` and waiting
+for its receipt, after a connection is available. The client generates its own
+`receipt` header in this mode.
+
+An initial failure raises `SubscriptionError`, with `reason` equal to
+`rejected`, `timeout`, `connection_lost`, or `unsubscribed`. The optional,
+synchronous `on_subscription_error` callback also reports failures during
+automatic resubscription, when there is no caller awaiting `subscribe()`.
+The rejected subscription is removed before the callback runs. Callbacks should
+not block; their exceptions are logged without terminating the frame reader.
+Raw broker error frames are available through `error.frame`, but are excluded
+from the exception's representation.
+
+Confirmed subscriptions are restored after reconnect with fresh receipt IDs.
+Unconfirmed or rejected subscriptions are not blindly replayed. Timeouts and
+cancellation remove local state and attempt bounded cleanup on the same
+connection. An `ERROR` without `receipt-id` fails all pending confirmations on
+that connection; it does not remove previously confirmed subscriptions.
+Neither subscription confirmation nor a publish receipt proves downstream
+business processing.
+
 ### Cleaning Up
 
 stompman takes care of cleaning up resources automatically. When you leave the context of async context managers `stompman.Client()`, or `client.begin()`, the necessary frames will be sent to the server.
@@ -152,6 +191,7 @@ stompman takes care of cleaning up resources automatically. When you leave the c
 
 - When connection is lost, stompman will attempt to handle it automatically. `stompman.FailedAllConnectAttemptsError` will be raised if all connection attempts fail. `stompman.FailedAllWriteAttemptsError` will be raised if connection succeeds but sending a frame or heartbeat lead to losing connection.
 - Set `keep_alive_on_connection_failure=True` to keep background heartbeat and read recovery running after a retry cycle is exhausted. The default remains `False`, and errors from `Client.send()` still follow `connect_retry_attempts` and `write_retry_attempts`.
+- Connections that succeed and immediately fail are spaced by `connect_retry_interval` as well, preventing a tight reconnect loop.
 - If no messages are received for `no_message_restart_interval` (defaults to 1 hour), stompman will force a reconnect. Set to `None` to disable.
 - To implement health checks, use `stompman.Client.is_alive()` — it will return `True` if everything is OK and `False` if server is not responding.
 - `stompman` will write log warnings when connection is lost, after successful reconnection or invalid state during ack/nack.

--- a/packages/stompman/stompman/__init__.py
+++ b/packages/stompman/stompman/__init__.py
@@ -7,6 +7,7 @@ from stompman.errors import (
     FailedAllConnectAttemptsError,
     FailedAllWriteAttemptsError,
     StompProtocolConnectionIssue,
+    SubscriptionError,
     UnsupportedProtocolVersion,
 )
 from stompman.frames import (
@@ -30,7 +31,7 @@ from stompman.frames import (
     SubscribeFrame,
     UnsubscribeFrame,
 )
-from stompman.logger import LOGGER as logger  # noqa: N811
+from stompman.logger import LOGGER as logger  # ruff: ignore[constant-imported-as-non-constant]
 from stompman.serde import FrameParser, dump_frame
 from stompman.subscription import AckableMessageFrame, AutoAckSubscription, ManualAckSubscription
 from stompman.transaction import Transaction
@@ -67,6 +68,7 @@ __all__ = [
     "SendFrame",
     "StompProtocolConnectionIssue",
     "SubscribeFrame",
+    "SubscriptionError",
     "Transaction",
     "UnsubscribeFrame",
     "UnsupportedProtocolVersion",

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -24,8 +24,14 @@ from stompman.frames import (
     SendFrame,
 )
 from stompman.logger import LOGGER
-from stompman.subscription import AckableMessageFrame, ActiveSubscriptions, AutoAckSubscription, ManualAckSubscription
-from stompman.transaction import Transaction
+from stompman.subscription import (
+    AckableMessageFrame,
+    ActiveSubscriptions,
+    AutoAckSubscription,
+    ManualAckSubscription,
+    resubscribe_to_active_subscriptions,
+)
+from stompman.transaction import Transaction, commit_pending_transactions
 
 
 async def _run_handler_with_safety_net(coro: Coroutine[Any, Any, Any]) -> None:
@@ -82,7 +88,6 @@ class Client:
                 connection_confirmation_timeout=self.connection_confirmation_timeout,
                 disconnect_confirmation_timeout=self.disconnect_confirmation_timeout,
                 active_subscriptions=self._active_subscriptions,
-                active_transactions=self._active_transactions,
             ),
             connection_class=self.connection_class,
             connect_retry_attempts=self.connect_retry_attempts,
@@ -94,10 +99,17 @@ class Client:
             no_message_restart_interval=self.no_message_restart_interval,
             keep_alive_on_connection_failure=self.keep_alive_on_connection_failure,
             on_connection_lost=self._active_subscriptions.connection_lost,
+            restore_connection=self._restore_connection,
             ssl=self.ssl,
         )
         if self.max_concurrent_handlers is not None:
             self._handler_semaphore = asyncio.Semaphore(self.max_concurrent_handlers)
+
+    async def _restore_connection(self, connection: AbstractConnection) -> None:
+        await resubscribe_to_active_subscriptions(
+            connection=connection, active_subscriptions=self._active_subscriptions
+        )
+        await commit_pending_transactions(connection=connection, active_transactions=self._active_transactions)
 
     async def __aenter__(self) -> Self:
         self._task_group = await self._exit_stack.enter_async_context(asyncio.TaskGroup())

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -105,7 +105,12 @@ class Client:
         if self.max_concurrent_handlers is not None:
             self._handler_semaphore = asyncio.Semaphore(self.max_concurrent_handlers)
 
-    async def _restore_connection(self, connection: AbstractConnection) -> None:
+    def _restore_connection(self, connection: AbstractConnection) -> Callable[[], Coroutine[Any, Any, None]] | None:
+        if not self._active_subscriptions.get_all() and not self._active_transactions:
+            return None
+        return partial(self._replay_connection_state, connection)
+
+    async def _replay_connection_state(self, connection: AbstractConnection) -> None:
         await resubscribe_to_active_subscriptions(
             connection=connection, active_subscriptions=self._active_subscriptions
         )

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -13,6 +13,7 @@ from stompman.config import ConnectionParameters, Heartbeat
 from stompman.connection import AbstractConnection, Connection
 from stompman.connection_lifespan import ConnectionLifespan
 from stompman.connection_manager import ConnectionManager
+from stompman.errors import SubscriptionError
 from stompman.frames import (
     AckMode,
     ConnectedFrame,
@@ -92,6 +93,7 @@ class Client:
             check_server_alive_interval_factor=self.check_server_alive_interval_factor,
             no_message_restart_interval=self.no_message_restart_interval,
             keep_alive_on_connection_failure=self.keep_alive_on_connection_failure,
+            on_connection_lost=self._active_subscriptions.connection_lost,
             ssl=self.ssl,
         )
         if self.max_concurrent_handlers is not None:
@@ -112,6 +114,7 @@ class Client:
         finally:
             self._listen_task.cancel()
             await asyncio.wait([self._listen_task])
+            await self._active_subscriptions.cancel_confirmation_tasks()
             await self._exit_stack.aclose()
 
     async def _listen_to_frames(self) -> None:
@@ -147,11 +150,18 @@ class Client:
                                     s.release()
 
                                 task.add_done_callback(_release)
-                    case ErrorFrame():
-                        if self.on_error_frame:
-                            self.on_error_frame(frame)
-                    case HeartbeatFrame() | ConnectedFrame() | ReceiptFrame():
+                    case ErrorFrame() | ReceiptFrame():
+                        self._handle_subscription_frame(frame, epoch=epoch)
+                    case HeartbeatFrame() | ConnectedFrame():
                         pass
+
+    def _handle_subscription_frame(self, frame: ErrorFrame | ReceiptFrame, *, epoch: int) -> None:
+        if isinstance(frame, ReceiptFrame):
+            self._active_subscriptions.handle_receipt(frame, epoch=epoch)
+        else:
+            self._active_subscriptions.handle_error(frame, epoch=epoch)
+            if self.on_error_frame:
+                self.on_error_frame(frame)
 
     async def send(
         self,
@@ -189,6 +199,8 @@ class Client:
         headers: dict[str, str] | None = None,
         on_suppressed_exception: Callable[[Exception, MessageFrame], Any],
         suppressed_exception_classes: tuple[type[Exception], ...] = (Exception,),
+        receipt_timeout: float | None = None,
+        on_subscription_error: Callable[[SubscriptionError], Any] | None = None,
     ) -> "AutoAckSubscription":
         subscription = AutoAckSubscription(
             destination=destination,
@@ -197,6 +209,8 @@ class Client:
             ack=ack,
             on_suppressed_exception=on_suppressed_exception,
             suppressed_exception_classes=suppressed_exception_classes,
+            receipt_timeout=receipt_timeout,
+            on_subscription_error=on_subscription_error,
             _connection_manager=self._connection_manager,
             _active_subscriptions=self._active_subscriptions,
         )
@@ -210,12 +224,16 @@ class Client:
         *,
         ack: AckMode = "client-individual",
         headers: dict[str, str] | None = None,
+        receipt_timeout: float | None = None,
+        on_subscription_error: Callable[[SubscriptionError], Any] | None = None,
     ) -> "ManualAckSubscription":
         subscription = ManualAckSubscription(
             destination=destination,
             handler=handler,
             headers=headers,
             ack=ack,
+            receipt_timeout=receipt_timeout,
+            on_subscription_error=on_subscription_error,
             _connection_manager=self._connection_manager,
             _active_subscriptions=self._active_subscriptions,
         )

--- a/packages/stompman/stompman/client.py
+++ b/packages/stompman/stompman/client.py
@@ -123,27 +123,12 @@ class Client:
                 match frame:
                     case MessageFrame():
                         self._connection_manager._last_message_received_time = time.time()
-                        received_at_reconnection_count = epoch
                         if subscription := self._active_subscriptions.get_by_id(frame.headers["subscription"]):
-                            if self._handler_semaphore is not None:
-                                await self._handler_semaphore.acquire()
-                            handler_coro = (
-                                subscription._run_handler(
-                                    frame=frame,
-                                    received_at_reconnection_count=received_at_reconnection_count,
-                                )
-                                if isinstance(subscription, AutoAckSubscription)
-                                else subscription.handler(
-                                    AckableMessageFrame(
-                                        headers=frame.headers,
-                                        body=frame.body,
-                                        _subscription=subscription,
-                                        _received_at_reconnection_count=received_at_reconnection_count,
-                                    )
-                                )
+                            reserved = await self._reserve_handler_slot()
+                            task = task_group.create_task(
+                                self._run_message_handler(subscription, frame, epoch=epoch, reserved=reserved)
                             )
-                            task = task_group.create_task(_run_handler_with_safety_net(handler_coro))
-                            if self._handler_semaphore is not None:
+                            if reserved and self._handler_semaphore is not None:
                                 semaphore = self._handler_semaphore
 
                                 def _release(_t: asyncio.Task[None], s: asyncio.Semaphore = semaphore) -> None:
@@ -154,6 +139,63 @@ class Client:
                         self._handle_subscription_frame(frame, epoch=epoch)
                     case HeartbeatFrame() | ConnectedFrame():
                         pass
+
+    async def _reserve_handler_slot(self) -> bool:
+        semaphore = self._handler_semaphore
+        if semaphore is None:
+            return False
+        if not semaphore.locked():
+            await semaphore.acquire()
+            return True
+        if self._active_subscriptions.pending_receipts:
+            return False
+        capacity = asyncio.create_task(semaphore.acquire())
+        confirmation = asyncio.create_task(self._active_subscriptions.confirmation_started.wait())
+        reserved = False
+        try:
+            await asyncio.wait((capacity, confirmation), return_when=asyncio.FIRST_COMPLETED)
+            if capacity.done() and not capacity.cancelled():
+                reserved = capacity.result()
+            return reserved
+        finally:
+            confirmation.cancel()
+            if not capacity.done():
+                capacity.cancel()
+            await asyncio.gather(capacity, confirmation, return_exceptions=True)
+            if not reserved and not capacity.cancelled() and capacity.result():
+                semaphore.release()
+
+    async def _run_message_handler(
+        self,
+        subscription: AutoAckSubscription | ManualAckSubscription,
+        frame: MessageFrame,
+        *,
+        epoch: int,
+        reserved: bool,
+    ) -> None:
+        if self._handler_semaphore is not None and not reserved:
+            async with self._handler_semaphore:
+                await self._invoke_message_handler(subscription, frame, epoch=epoch)
+        else:
+            await self._invoke_message_handler(subscription, frame, epoch=epoch)
+
+    @staticmethod
+    async def _invoke_message_handler(
+        subscription: AutoAckSubscription | ManualAckSubscription, frame: MessageFrame, *, epoch: int
+    ) -> None:
+        handler = (
+            subscription._run_handler(frame=frame, received_at_reconnection_count=epoch)
+            if isinstance(subscription, AutoAckSubscription)
+            else subscription.handler(
+                AckableMessageFrame(
+                    headers=frame.headers,
+                    body=frame.body,
+                    _subscription=subscription,
+                    _received_at_reconnection_count=epoch,
+                )
+            )
+        )
+        await _run_handler_with_safety_net(handler)
 
     def _handle_subscription_frame(self, frame: ErrorFrame | ReceiptFrame, *, epoch: int) -> None:
         if isinstance(frame, ReceiptFrame):

--- a/packages/stompman/stompman/connection_lifespan.py
+++ b/packages/stompman/stompman/connection_lifespan.py
@@ -15,12 +15,7 @@ from stompman.frames import (
     DisconnectFrame,
     ReceiptFrame,
 )
-from stompman.subscription import (
-    ActiveSubscriptions,
-    resubscribe_to_active_subscriptions,
-    unsubscribe_from_all_active_subscriptions,
-)
-from stompman.transaction import ActiveTransactions, commit_pending_transactions
+from stompman.subscription import ActiveSubscriptions, unsubscribe_from_all_active_subscriptions
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -44,10 +39,9 @@ class ConnectionLifespan(AbstractConnectionLifespan):
     connection_confirmation_timeout: int
     disconnect_confirmation_timeout: int
     active_subscriptions: ActiveSubscriptions
-    active_transactions: ActiveTransactions
     set_heartbeat_interval: Callable[[Heartbeat], Any]
 
-    async def _establish_connection(self) -> EstablishedConnectionResult | StompProtocolConnectionIssue:
+    async def enter(self) -> EstablishedConnectionResult | StompProtocolConnectionIssue:
         connect_headers = cast(
             "ConnectHeaders",
             self.connection_parameters.connect_headers
@@ -85,15 +79,6 @@ class ConnectionLifespan(AbstractConnectionLifespan):
         server_heartbeat = Heartbeat.from_header(connected_frame.headers["heart-beat"])
         self.set_heartbeat_interval(server_heartbeat)
         return EstablishedConnectionResult(server_heartbeat=server_heartbeat)
-
-    async def enter(self) -> EstablishedConnectionResult | StompProtocolConnectionIssue:
-        connection_result = await self._establish_connection()
-        if isinstance(connection_result, EstablishedConnectionResult):
-            await resubscribe_to_active_subscriptions(
-                connection=self.connection, active_subscriptions=self.active_subscriptions
-            )
-            await commit_pending_transactions(connection=self.connection, active_transactions=self.active_transactions)
-        return connection_result
 
     async def _take_receipt_frame(self) -> None:
         async for frame in self.connection.read_frames():

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
 from ssl import SSLContext
@@ -62,6 +62,7 @@ class ConnectionManager:
     check_server_alive_interval_factor: int
     no_message_restart_interval: timedelta | None
     keep_alive_on_connection_failure: bool = False
+    on_connection_lost: Callable[[AbstractConnection], None] | None = None
 
     _active_connection_state: ActiveConnectionState | None = field(default=None, init=False)
     _reconnect_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
@@ -70,6 +71,8 @@ class ConnectionManager:
     _monitor_no_message_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _reconnection_count: int = field(default=0, init=False)
     _last_message_received_time: float = field(init=False, default_factory=time.time)
+    _connected_at_monotonic: float = field(init=False, default=0)
+    _reconnect_not_before: float = field(init=False, default=0)
 
     async def __aenter__(self) -> Self:
         await self._task_group.__aenter__()
@@ -201,6 +204,8 @@ class ConnectionManager:
             return connection_result
         finally:
             if not connection_established:
+                if self.on_connection_lost is not None:
+                    self.on_connection_lost(connection)
                 await connection.close()
 
     async def _get_active_connection_state(self, *, is_initial_call: bool = False) -> ActiveConnectionState:
@@ -213,11 +218,15 @@ class ConnectionManager:
             if self._active_connection_state:
                 return self._active_connection_state
 
+            if (delay := self._reconnect_not_before - time.monotonic()) > 0:
+                await asyncio.sleep(delay)
+
             for attempt in range(self.connect_retry_attempts):
                 connection_result = await self._connect_to_any_server()
 
                 if isinstance(connection_result, ActiveConnectionState):
                     self._active_connection_state = connection_result
+                    self._connected_at_monotonic = time.monotonic()
                     self._last_message_received_time = time.time()
                     self._restart_no_message_monitor()
                     if not is_initial_call:
@@ -246,6 +255,11 @@ class ConnectionManager:
         )
         self._active_connection_state = None
         self._reconnection_count += 1
+        # A successful handshake must not bypass retry spacing when the peer
+        # immediately closes the connection again.
+        self._reconnect_not_before = self._connected_at_monotonic + self.connect_retry_interval
+        if self.on_connection_lost is not None:
+            self.on_connection_lost(connection_state.connection)
         await connection_state.connection.close()
 
     async def write_heartbeat_reconnecting(self) -> None:

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -17,7 +17,7 @@ from stompman.errors import (
     FailedAllConnectAttemptsError,
     FailedAllWriteAttemptsError,
 )
-from stompman.frames import AckFrame, AnyClientFrame, AnyServerFrame, NackFrame
+from stompman.frames import AbortFrame, AckFrame, AnyClientFrame, AnyServerFrame, CommitFrame, NackFrame
 from stompman.logger import LOGGER
 
 if TYPE_CHECKING:
@@ -231,7 +231,7 @@ class ConnectionManager:
         issues: list[AnyConnectionIssue] = []
         for _ in range(self.connect_retry_attempts):
             state = await self._get_active_connection_state(is_initial_call=is_initial_call)
-            if state.restoration_task is not None:
+            if state.restoration_task is not None and not state.restoration_task.done():
                 # Wait without forwarding caller cancellation to shared replay.
                 # The frame reader uses the established connection immediately,
                 # so receipts are processed even while replay writes are blocked.
@@ -341,6 +341,15 @@ class ConnectionManager:
     async def maybe_write_frame(self, frame: AnyClientFrame) -> bool:
         if not (connection_state := self._active_connection_state):
             _log_dropped_frame(frame, reason="no active connection")
+            return False
+        if (
+            isinstance(frame, CommitFrame | AbortFrame)
+            and connection_state.restoration_task is not None
+            and not connection_state.restoration_task.done()
+        ):
+            # Finalization must not overtake replay of buffered transaction
+            # messages. ACK/NACK and subscription cleanup remain available.
+            _log_dropped_frame(frame, reason="connection replay in progress")
             return False
         try:
             await connection_state.connection.write_frame(frame)

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
 from ssl import SSLContext
@@ -30,6 +30,7 @@ class ActiveConnectionState:
     lifespan: "AbstractConnectionLifespan"
     server_heartbeat: Heartbeat
     connected_at: float
+    restoration_task: asyncio.Task[None] | None = field(default=None, repr=False, compare=False)
 
     def is_alive(self, check_server_alive_interval_factor: int) -> bool:
         threshold_seconds = self.server_heartbeat.will_send_interval_ms / 1000 * check_server_alive_interval_factor
@@ -63,6 +64,7 @@ class ConnectionManager:
     no_message_restart_interval: timedelta | None
     keep_alive_on_connection_failure: bool = False
     on_connection_lost: Callable[[AbstractConnection], None] | None = None
+    restore_connection: Callable[[AbstractConnection], Awaitable[None]] | None = None
 
     _active_connection_state: ActiveConnectionState | None = field(default=None, init=False)
     _reconnect_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
@@ -77,7 +79,7 @@ class ConnectionManager:
     async def __aenter__(self) -> Self:
         await self._task_group.__aenter__()
         self._send_heartbeat_task = self._task_group.create_task(asyncio.sleep(0))
-        self._active_connection_state = await self._get_active_connection_state(is_initial_call=True)
+        self._active_connection_state = await self._get_restored_connection_state(is_initial_call=True)
         return self
 
     async def __aexit__(
@@ -88,6 +90,9 @@ class ConnectionManager:
         if self._monitor_no_message_task is not None:
             self._monitor_no_message_task.cancel()
             tasks.append(self._monitor_no_message_task)
+        if (state := self._active_connection_state) is not None and state.restoration_task is not None:
+            state.restoration_task.cancel()
+            tasks.append(state.restoration_task)
         await asyncio.wait(tasks)
         try:
             await self._task_group.__aexit__(exc_type, exc_value, traceback)
@@ -200,6 +205,11 @@ class ConnectionManager:
                     lifespan=lifespan,
                     server_heartbeat=connection_result.server_heartbeat,
                     connected_at=time.time(),
+                    restoration_task=(
+                        self._task_group.create_task(self._restore_connection(connection))
+                        if self.restore_connection is not None
+                        else None
+                    ),
                 )
             return connection_result
         finally:
@@ -207,6 +217,31 @@ class ConnectionManager:
                 if self.on_connection_lost is not None:
                     self.on_connection_lost(connection)
                 await connection.close()
+
+    async def _restore_connection(self, connection: AbstractConnection) -> None:
+        assert self.restore_connection is not None  # ruff: ignore[assert] - internal invariant
+        try:
+            await self.restore_connection(connection)
+        except ConnectionLostError as error:
+            state = self._active_connection_state
+            if state is not None and state.connection is connection:
+                await self._discard_failed_connection_state(state, error)
+
+    async def _get_restored_connection_state(self, *, is_initial_call: bool = False) -> ActiveConnectionState:
+        issues: list[AnyConnectionIssue] = []
+        for _ in range(self.connect_retry_attempts):
+            state = await self._get_active_connection_state(is_initial_call=is_initial_call)
+            if state.restoration_task is not None:
+                # Wait without forwarding caller cancellation to shared replay.
+                # The frame reader uses the established connection immediately,
+                # so receipts are processed even while replay writes are blocked.
+                await asyncio.wait([state.restoration_task])
+            if self._active_connection_state is state:
+                if state.restoration_task is not None:
+                    state.restoration_task.result()
+                return state
+            issues.append(ConnectionLostOnLifespanEnter())
+        raise FailedAllConnectAttemptsError(retry_attempts=self.connect_retry_attempts, issues=issues)
 
     async def _get_active_connection_state(self, *, is_initial_call: bool = False) -> ActiveConnectionState:
         if self._active_connection_state:
@@ -260,6 +295,10 @@ class ConnectionManager:
         self._reconnect_not_before = self._connected_at_monotonic + self.connect_retry_interval
         if self.on_connection_lost is not None:
             self.on_connection_lost(connection_state.connection)
+        restoration = connection_state.restoration_task
+        if restoration is not None and restoration is not asyncio.current_task() and not restoration.done():
+            restoration.cancel()
+            await asyncio.gather(restoration, return_exceptions=True)
         await connection_state.connection.close()
 
     async def write_heartbeat_reconnecting(self) -> None:
@@ -274,7 +313,7 @@ class ConnectionManager:
 
     async def write_frame_reconnecting(self, frame: AnyClientFrame) -> None:
         for _ in range(self.write_retry_attempts):
-            connection_state = await self._get_active_connection_state()
+            connection_state = await self._get_restored_connection_state()
             try:
                 return await connection_state.connection.write_frame(frame)
             except ConnectionLostError as error:

--- a/packages/stompman/stompman/connection_manager.py
+++ b/packages/stompman/stompman/connection_manager.py
@@ -23,6 +23,8 @@ from stompman.logger import LOGGER
 if TYPE_CHECKING:
     from stompman.connection_lifespan import AbstractConnectionLifespan, ConnectionLifespanFactory
 
+ConnectionRestoration = Callable[[], Awaitable[None]]
+
 
 @dataclass(frozen=True, kw_only=True, slots=True)
 class ActiveConnectionState:
@@ -64,7 +66,7 @@ class ConnectionManager:
     no_message_restart_interval: timedelta | None
     keep_alive_on_connection_failure: bool = False
     on_connection_lost: Callable[[AbstractConnection], None] | None = None
-    restore_connection: Callable[[AbstractConnection], Awaitable[None]] | None = None
+    restore_connection: Callable[[AbstractConnection], ConnectionRestoration | None] | None = None
 
     _active_connection_state: ActiveConnectionState | None = field(default=None, init=False)
     _reconnect_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
@@ -199,6 +201,7 @@ class ConnectionManager:
                 return ConnectionLostOnLifespanEnter()
 
             if isinstance(connection_result, EstablishedConnectionResult):
+                restoration = self.restore_connection(connection) if self.restore_connection is not None else None
                 connection_established = True
                 return ActiveConnectionState(
                     connection=connection,
@@ -206,8 +209,8 @@ class ConnectionManager:
                     server_heartbeat=connection_result.server_heartbeat,
                     connected_at=time.time(),
                     restoration_task=(
-                        self._task_group.create_task(self._restore_connection(connection))
-                        if self.restore_connection is not None
+                        self._task_group.create_task(self._restore_connection(connection, restoration))
+                        if restoration is not None
                         else None
                     ),
                 )
@@ -218,10 +221,9 @@ class ConnectionManager:
                     self.on_connection_lost(connection)
                 await connection.close()
 
-    async def _restore_connection(self, connection: AbstractConnection) -> None:
-        assert self.restore_connection is not None  # ruff: ignore[assert] - internal invariant
+    async def _restore_connection(self, connection: AbstractConnection, restoration: ConnectionRestoration) -> None:
         try:
-            await self.restore_connection(connection)
+            await restoration()
         except ConnectionLostError as error:
             state = self._active_connection_state
             if state is not None and state.connection is connection:

--- a/packages/stompman/stompman/errors.py
+++ b/packages/stompman/stompman/errors.py
@@ -1,6 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal
 
-from stompman.config import ConnectionParameters  # noqa: TC001
+from stompman.config import ConnectionParameters  # ruff: ignore[typing-only-first-party-import]
 from stompman.frames import ErrorFrame, HeartbeatFrame, MessageFrame, ReceiptFrame
 
 
@@ -52,3 +53,12 @@ class FailedAllConnectAttemptsError(Error):
 @dataclass(kw_only=True)
 class FailedAllWriteAttemptsError(Error):
     retry_attempts: int
+
+
+@dataclass(kw_only=True)
+class SubscriptionError(Error):
+    """A receipt-confirmed subscription could not be established or restored."""
+
+    subscription_id: str
+    reason: Literal["rejected", "timeout", "connection_lost", "unsubscribed"]
+    frame: ErrorFrame | None = field(default=None, repr=False)

--- a/packages/stompman/stompman/frames.py
+++ b/packages/stompman/stompman/frames.py
@@ -37,6 +37,7 @@ SubscribeHeaders = TypedDict(
         "id": str,
         "destination": str,
         "ack": NotRequired[AckMode],
+        "receipt": NotRequired[str],
         "content-length": NotRequired[str],
     },
 )
@@ -115,6 +116,7 @@ ErrorHeaders = TypedDict(
     "ErrorHeaders",
     {
         "message": str,
+        "receipt-id": NotRequired[str],
         "content-length": NotRequired[str],
         "content-type": NotRequired[str],
     },

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -38,6 +38,7 @@ class ActiveSubscriptions:
     event: asyncio.Event = field(default_factory=asyncio.Event, init=False)
     pending_receipts: dict[str, _PendingConfirmation] = field(default_factory=dict, init=False)
     confirmation_tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False)
+    confirmation_started: asyncio.Event = field(default_factory=asyncio.Event, init=False)
 
     def __post_init__(self) -> None:
         self.event.set()
@@ -70,6 +71,8 @@ class ActiveSubscriptions:
     def handle_receipt(self, frame: ReceiptFrame, *, epoch: int) -> None:
         if (pending := self.pending_receipts.get(frame.headers["receipt-id"])) and pending.epoch == epoch:
             del self.pending_receipts[pending.receipt_id]
+            if not self.pending_receipts:
+                self.confirmation_started.clear()
             pending.subscription._pending_confirmation = None
             if not pending.result.done():
                 pending.result.set_result(None)
@@ -164,6 +167,7 @@ class BaseSubscription:
         )
         self._pending_confirmation = pending
         self._active_subscriptions.pending_receipts[pending.receipt_id] = pending
+        self._active_subscriptions.confirmation_started.set()
         try:
             async with asyncio.timeout_at(pending.deadline):
                 await connection.write_frame(
@@ -177,6 +181,10 @@ class BaseSubscription:
         except TimeoutError as error:
             failure = SubscriptionError(subscription_id=self.id, reason="timeout")
             self._fail_confirmation(pending, failure)
+            # A receipt can arrive before the socket write finishes draining.
+            # A failed subscribe must not leave that already-confirmed entry
+            # behind without a subscription handle for the caller to close.
+            self._active_subscriptions.delete_by_id(self.id)
             await self._cleanup_confirmation(pending)
             raise failure from error
         except BaseException as error:
@@ -201,6 +209,13 @@ class BaseSubscription:
                 async with asyncio.timeout_at(pending.deadline):
                     error = await asyncio.shield(pending.result)
         except TimeoutError as timeout_error:
+            # Prefer a receipt already processed by the reader over a deadline
+            # cancellation delivered before this waiter was rescheduled.
+            if pending.result.done():
+                error = pending.result.result()
+                if error is not None:
+                    raise error from timeout_error
+                return
             error = SubscriptionError(subscription_id=self.id, reason="timeout")
             self._fail_confirmation(pending, error)
             await self._cleanup_confirmation(pending)
@@ -224,6 +239,8 @@ class BaseSubscription:
     ) -> None:
         if self._active_subscriptions.pending_receipts.pop(pending.receipt_id, None) is None:
             return
+        if not self._active_subscriptions.pending_receipts:
+            self._active_subscriptions.confirmation_started.clear()
         self._pending_confirmation = None
         self._active_subscriptions.delete_by_id(self.id)
         if not pending.result.done():

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -155,7 +155,9 @@ class BaseSubscription:
         self._active_subscriptions.delete_by_id(self.id)
         await self._connection_manager.maybe_write_frame(UnsubscribeFrame(headers={"id": self.id}))
 
-    async def _send_confirmed_subscription(self, connection: AbstractConnection) -> _PendingConfirmation:
+    async def _send_confirmed_subscription(
+        self, connection: AbstractConnection, *, restoring: bool = False
+    ) -> _PendingConfirmation:
         assert self.receipt_timeout is not None  # ruff: ignore[assert] - internal invariant
         pending = _PendingConfirmation(
             subscription=self,
@@ -180,11 +182,10 @@ class BaseSubscription:
                 )
         except TimeoutError as error:
             failure = SubscriptionError(subscription_id=self.id, reason="timeout")
-            self._fail_confirmation(pending, failure)
+            self._fail_confirmation(pending, failure, include_confirmed=True)
             # A receipt can arrive before the socket write finishes draining.
             # A failed subscribe must not leave that already-confirmed entry
             # behind without a subscription handle for the caller to close.
-            self._active_subscriptions.delete_by_id(self.id)
             await self._cleanup_confirmation(pending)
             raise failure from error
         except BaseException as error:
@@ -192,11 +193,15 @@ class BaseSubscription:
                 pending,
                 SubscriptionError(
                     subscription_id=self.id,
-                    reason="unsubscribed" if isinstance(error, asyncio.CancelledError) else "connection_lost",
+                    reason=(
+                        "unsubscribed"
+                        if isinstance(error, asyncio.CancelledError) and not restoring
+                        else "connection_lost"
+                    ),
                 ),
-                notify=not isinstance(error, asyncio.CancelledError),
+                notify=restoring or not isinstance(error, asyncio.CancelledError),
+                include_confirmed=True,
             )
-            self._active_subscriptions.delete_by_id(self.id)
             await self._cleanup_confirmation(pending)
             raise
         return pending
@@ -235,10 +240,25 @@ class BaseSubscription:
             raise error
 
     def _fail_confirmation(
-        self, pending: _PendingConfirmation, error: SubscriptionError, *, notify: bool = True
+        self,
+        pending: _PendingConfirmation,
+        error: SubscriptionError,
+        *,
+        notify: bool = True,
+        include_confirmed: bool = False,
     ) -> None:
         if self._active_subscriptions.pending_receipts.pop(pending.receipt_id, None) is None:
-            return
+            if not include_confirmed:
+                return
+            # A write may fail after its receipt. Notify once, without removing
+            # a subscription already being restored on a newer connection.
+            if (
+                self._pending_confirmation is not None
+                or not pending.result.done()
+                or pending.result.result() is not None
+                or not self._active_subscriptions.contains_by_id(self.id)
+            ):
+                return
         if not self._active_subscriptions.pending_receipts:
             self._active_subscriptions.confirmation_started.clear()
         self._pending_confirmation = None
@@ -283,7 +303,7 @@ class BaseSubscription:
             )
         else:
             try:
-                pending = await self._send_confirmed_subscription(connection)
+                pending = await self._send_confirmed_subscription(connection, restoring=True)
             except SubscriptionError:
                 return
             self._active_subscriptions.watch_confirmation(pending)

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -1,16 +1,21 @@
 import asyncio
+import math
 from collections.abc import Awaitable, Callable, Coroutine
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
 
 from stompman.connection import AbstractConnection
 from stompman.connection_manager import ConnectionManager
+from stompman.errors import ConnectionLostError, SubscriptionError
 from stompman.frames import (
     AckFrame,
     AckMode,
+    ErrorFrame,
     MessageFrame,
     NackFrame,
+    ReceiptFrame,
     SubscribeFrame,
     UnsubscribeFrame,
 )
@@ -18,9 +23,21 @@ from stompman.logger import LOGGER
 
 
 @dataclass(kw_only=True, slots=True, frozen=True)
+class _PendingConfirmation:
+    subscription: "BaseSubscription"
+    connection: AbstractConnection
+    receipt_id: str
+    epoch: int
+    deadline: float
+    result: asyncio.Future[SubscriptionError | None]
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
 class ActiveSubscriptions:
     subscriptions: dict[str, "AutoAckSubscription | ManualAckSubscription"] = field(default_factory=dict, init=False)
     event: asyncio.Event = field(default_factory=asyncio.Event, init=False)
+    pending_receipts: dict[str, _PendingConfirmation] = field(default_factory=dict, init=False)
+    confirmation_tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False)
 
     def __post_init__(self) -> None:
         self.event.set()
@@ -50,17 +67,76 @@ class ActiveSubscriptions:
     async def wait_until_empty(self) -> bool:
         return await self.event.wait()
 
+    def handle_receipt(self, frame: ReceiptFrame, *, epoch: int) -> None:
+        if (pending := self.pending_receipts.get(frame.headers["receipt-id"])) and pending.epoch == epoch:
+            del self.pending_receipts[pending.receipt_id]
+            pending.subscription._pending_confirmation = None
+            if not pending.result.done():
+                pending.result.set_result(None)
+
+    def handle_error(self, frame: ErrorFrame, *, epoch: int) -> None:
+        receipt_id = frame.headers.get("receipt-id")
+        if receipt_id is not None:
+            pending = self.pending_receipts.get(receipt_id)
+            affected = [pending] if pending is not None else []
+        else:
+            # An uncorrelated ERROR cannot safely confirm any in-flight
+            # subscription. Confirmed subscriptions remain eligible for recovery.
+            affected = list(self.pending_receipts.values())
+        for pending in affected:
+            if pending.epoch != epoch:
+                continue
+            pending.subscription._fail_confirmation(
+                pending, SubscriptionError(subscription_id=pending.subscription.id, reason="rejected", frame=frame)
+            )
+
+    def connection_lost(self, connection: AbstractConnection) -> None:
+        for pending in list(self.pending_receipts.values()):
+            if pending.connection is connection:
+                pending.subscription._fail_confirmation(
+                    pending, SubscriptionError(subscription_id=pending.subscription.id, reason="connection_lost")
+                )
+
+    def watch_confirmation(self, pending: _PendingConfirmation) -> None:
+        task = asyncio.create_task(pending.subscription._watch_confirmation(pending))
+        self.confirmation_tasks.add(task)
+        task.add_done_callback(self.confirmation_tasks.discard)
+
+    async def cancel_confirmation_tasks(self) -> None:
+        tasks = tuple(self.confirmation_tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self.confirmation_tasks.difference_update(tasks)
+
 
 @dataclass(kw_only=True, slots=True)
 class BaseSubscription:
-    id: str = field(default_factory=lambda: _make_subscription_id(), init=False)  # noqa: PLW0108
+    id: str = field(default_factory=lambda: _make_subscription_id(), init=False)  # ruff: ignore[unnecessary-lambda]
     destination: str
     headers: dict[str, str] | None
     ack: AckMode
     _connection_manager: ConnectionManager
     _active_subscriptions: ActiveSubscriptions
+    receipt_timeout: float | None = None
+    on_subscription_error: Callable[[SubscriptionError], Any] | None = None
+    _pending_confirmation: _PendingConfirmation | None = field(default=None, init=False, repr=False)
 
     async def _subscribe(self) -> None:
+        if self.receipt_timeout is not None:
+            if not math.isfinite(self.receipt_timeout) or self.receipt_timeout <= 0:
+                msg = "receipt_timeout must be a finite positive number"
+                raise ValueError(msg)
+            connection_state = await self._connection_manager._get_active_connection_state()
+            self._active_subscriptions.add(self)  # type: ignore[arg-type]
+            try:
+                pending = await self._send_confirmed_subscription(connection_state.connection)
+                await self._await_confirmation(pending)
+            except ConnectionLostError as error:
+                await self._connection_manager._discard_failed_connection_state(connection_state, error)
+                raise SubscriptionError(subscription_id=self.id, reason="connection_lost") from error
+            return
         await self._connection_manager.write_frame_reconnecting(
             SubscribeFrame.build(
                 subscription_id=self.id, destination=self.destination, ack=self.ack, headers=self.headers
@@ -69,8 +145,131 @@ class BaseSubscription:
         self._active_subscriptions.add(self)  # type: ignore[arg-type]
 
     async def unsubscribe(self) -> None:
+        if pending := self._pending_confirmation:
+            self._fail_confirmation(
+                pending, SubscriptionError(subscription_id=self.id, reason="unsubscribed"), notify=False
+            )
         self._active_subscriptions.delete_by_id(self.id)
         await self._connection_manager.maybe_write_frame(UnsubscribeFrame(headers={"id": self.id}))
+
+    async def _send_confirmed_subscription(self, connection: AbstractConnection) -> _PendingConfirmation:
+        assert self.receipt_timeout is not None  # ruff: ignore[assert] - internal invariant
+        pending = _PendingConfirmation(
+            subscription=self,
+            connection=connection,
+            receipt_id=_make_confirmation_id(),
+            epoch=self._connection_manager._reconnection_count,
+            deadline=asyncio.get_running_loop().time() + self.receipt_timeout,
+            result=asyncio.get_running_loop().create_future(),
+        )
+        self._pending_confirmation = pending
+        self._active_subscriptions.pending_receipts[pending.receipt_id] = pending
+        try:
+            async with asyncio.timeout_at(pending.deadline):
+                await connection.write_frame(
+                    SubscribeFrame.build(
+                        subscription_id=self.id,
+                        destination=self.destination,
+                        ack=self.ack,
+                        headers={**(self.headers or {}), "receipt": pending.receipt_id},
+                    )
+                )
+        except TimeoutError as error:
+            failure = SubscriptionError(subscription_id=self.id, reason="timeout")
+            self._fail_confirmation(pending, failure)
+            await self._cleanup_confirmation(pending)
+            raise failure from error
+        except BaseException as error:
+            self._fail_confirmation(
+                pending,
+                SubscriptionError(
+                    subscription_id=self.id,
+                    reason="unsubscribed" if isinstance(error, asyncio.CancelledError) else "connection_lost",
+                ),
+                notify=not isinstance(error, asyncio.CancelledError),
+            )
+            self._active_subscriptions.delete_by_id(self.id)
+            await self._cleanup_confirmation(pending)
+            raise
+        return pending
+
+    async def _await_confirmation(self, pending: _PendingConfirmation) -> None:
+        try:
+            if pending.result.done():
+                error = pending.result.result()
+            else:
+                async with asyncio.timeout_at(pending.deadline):
+                    error = await asyncio.shield(pending.result)
+        except TimeoutError as timeout_error:
+            error = SubscriptionError(subscription_id=self.id, reason="timeout")
+            self._fail_confirmation(pending, error)
+            await self._cleanup_confirmation(pending)
+            raise error from timeout_error
+        except asyncio.CancelledError:
+            was_active = self._active_subscriptions.contains_by_id(self.id)
+            pending = self._pending_confirmation or pending
+            self._fail_confirmation(
+                pending, SubscriptionError(subscription_id=self.id, reason="unsubscribed"), notify=False
+            )
+            # A receipt may have arrived just before cancellation.
+            self._active_subscriptions.delete_by_id(self.id)
+            if was_active:
+                await self._cleanup_confirmation(pending)
+            raise
+        if error is not None:
+            raise error
+
+    def _fail_confirmation(
+        self, pending: _PendingConfirmation, error: SubscriptionError, *, notify: bool = True
+    ) -> None:
+        if self._active_subscriptions.pending_receipts.pop(pending.receipt_id, None) is None:
+            return
+        self._pending_confirmation = None
+        self._active_subscriptions.delete_by_id(self.id)
+        if not pending.result.done():
+            pending.result.set_result(error)
+        if notify:
+            if self.on_subscription_error is None:
+                LOGGER.warning("subscription confirmation failed: %s", error)
+            else:
+                try:
+                    self.on_subscription_error(error)
+                except Exception:  # ruff: ignore[blind-except] - user callbacks must not terminate the frame reader
+                    LOGGER.exception("unhandled exception in subscription error callback")
+
+    async def _cleanup_confirmation(self, pending: _PendingConfirmation) -> None:
+        try:
+            async with asyncio.timeout(self.receipt_timeout):
+                await pending.connection.write_frame(UnsubscribeFrame(headers={"id": self.id}))
+        except (ConnectionLostError, TimeoutError) as error:
+            state = self._connection_manager._active_connection_state
+            if state is not None and state.connection is pending.connection:
+                await self._connection_manager._discard_failed_connection_state(
+                    state, ConnectionLostError(reason=error)
+                )
+
+    async def _watch_confirmation(self, pending: _PendingConfirmation) -> None:
+        # Failure notification and registry cleanup happen before waking us.
+        with suppress(SubscriptionError):
+            await self._await_confirmation(pending)
+
+    async def _resubscribe(self, connection: AbstractConnection) -> None:
+        if not self._active_subscriptions.contains_by_id(self.id):
+            return
+        if self._pending_confirmation is not None:
+            return
+        if self.receipt_timeout is None:
+            await connection.write_frame(
+                SubscribeFrame.build(
+                    subscription_id=self.id, destination=self.destination, ack=self.ack, headers=self.headers
+                )
+            )
+        else:
+            try:
+                pending = await self._send_confirmed_subscription(connection)
+            except SubscriptionError:
+                return
+            self._active_subscriptions.watch_confirmation(pending)
 
     async def _nack(self, frame: MessageFrame, *, received_at_reconnection_count: int) -> None:
         if not self._active_subscriptions.contains_by_id(self.id):
@@ -180,18 +379,15 @@ def _make_subscription_id() -> str:
     return str(uuid4())
 
 
+def _make_confirmation_id() -> str:
+    return str(uuid4())
+
+
 async def resubscribe_to_active_subscriptions(
     *, connection: AbstractConnection, active_subscriptions: ActiveSubscriptions
 ) -> None:
     for subscription in active_subscriptions.get_all():
-        await connection.write_frame(
-            SubscribeFrame.build(
-                subscription_id=subscription.id,
-                destination=subscription.destination,
-                ack=subscription.ack,
-                headers=subscription.headers,
-            )
-        )
+        await subscription._resubscribe(connection)
 
 
 async def unsubscribe_from_all_active_subscriptions(*, active_subscriptions: ActiveSubscriptions) -> None:

--- a/packages/stompman/stompman/subscription.py
+++ b/packages/stompman/stompman/subscription.py
@@ -131,7 +131,7 @@ class BaseSubscription:
             if not math.isfinite(self.receipt_timeout) or self.receipt_timeout <= 0:
                 msg = "receipt_timeout must be a finite positive number"
                 raise ValueError(msg)
-            connection_state = await self._connection_manager._get_active_connection_state()
+            connection_state = await self._connection_manager._get_restored_connection_state()
             self._active_subscriptions.add(self)  # type: ignore[arg-type]
             try:
                 pending = await self._send_confirmed_subscription(connection_state.connection)

--- a/packages/stompman/test_stompman/test_connection_manager.py
+++ b/packages/stompman/test_stompman/test_connection_manager.py
@@ -353,6 +353,34 @@ async def test_stale_connection_failure_does_not_clear_new_connection() -> None:
     assert manager._reconnection_count == 0
 
 
+@pytest.mark.parametrize("stable_connection", [True, False])
+async def test_short_lived_connection_obeys_retry_spacing(
+    monkeypatch: pytest.MonkeyPatch, *, stable_connection: bool
+) -> None:
+    manager = EnrichedConnectionManager(connection_class=BaseMockConnection)
+    state = ActiveConnectionState(
+        connection=BaseMockConnection(),
+        lifespan=mock.Mock(),
+        server_heartbeat=build_dataclass(Heartbeat),
+        connected_at=time.time(),
+    )
+    manager._active_connection_state = state
+    manager._connected_at_monotonic = time.monotonic() - (2 if stable_connection else 0)
+    await manager._discard_failed_connection_state(state, ConnectionLostError(reason="peer closed"))
+    delay = manager._reconnect_not_before - time.monotonic()
+    if stable_connection:
+        assert delay <= 0
+    else:
+        assert 0 < delay <= manager.connect_retry_interval
+    sleep = mock.AsyncMock()
+    monkeypatch.setattr("asyncio.sleep", sleep)
+    # Fail connecting so that no heartbeat or lifespan tasks are introduced.
+    monkeypatch.setattr(BaseMockConnection, "connect", mock.AsyncMock(return_value=None))
+    with pytest.raises(FailedAllConnectAttemptsError):
+        await manager._get_active_connection_state()
+    assert len(sleep.await_args_list) == manager.connect_retry_attempts + (not stable_connection)
+
+
 async def test_heartbeat_failure_is_fatal_by_default() -> None:
     class MockConnection(BaseMockConnection):
         write_heartbeat = mock.Mock(side_effect=build_dataclass(ConnectionLostError))

--- a/packages/stompman/test_stompman/test_integration.py
+++ b/packages/stompman/test_stompman/test_integration.py
@@ -47,8 +47,10 @@ async def create_client(connection_parameters: stompman.ConnectionParameters) ->
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("receipt_timeout", [None, 3.0])
 async def test_consumption_survives_forced_reconnects(
     connection_parameters: stompman.ConnectionParameters,
+    receipt_timeout: float | None,
 ) -> None:
     iterations = 3
     received: list[bytes] = []
@@ -75,7 +77,9 @@ async def test_consumption_survives_forced_reconnects(
                 await asyncio.wait_for(received_event.wait(), timeout=5)
                 assert payload in received, f"iteration {index}: {payload!r} not delivered"
 
-        subscription = await consumer.subscribe_with_manual_ack(destination=destination, handler=handle_message)
+        subscription = await consumer.subscribe_with_manual_ack(
+            destination=destination, handler=handle_message, receipt_timeout=receipt_timeout
+        )
         try:
             await consume_after_reconnects()
         finally:
@@ -85,6 +89,42 @@ async def test_consumption_survives_forced_reconnects(
         f"expected exactly {iterations} deliveries, got {len(received)}: {received}. "
         "prior-acked messages are being redelivered after every forced reconnect"
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("port", [9000, 9001], ids=["artemis", "classic"])
+async def test_receipt_rejection_does_not_replay_subscription(port: int) -> None:
+    error_frames: list[stompman.ErrorFrame] = []
+    parameters = stompman.ConnectionParameters("127.0.0.1", port, "admin", ":=123")
+    destination = f"confirmation-{uuid4()}"
+    received: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
+
+    async def handle_message(frame: stompman.AckableMessageFrame) -> None:  # ruff: ignore[unused-async]
+        if not received.done():
+            received.set_result(frame.body)
+
+    async with stompman.Client(
+        servers=[parameters], on_error_frame=error_frames.append, connection_confirmation_timeout=10
+    ) as client:
+        with pytest.raises(stompman.SubscriptionError, match="rejected"):
+            await client.subscribe_with_manual_ack(
+                destination,
+                handle_message,
+                ack="auto",
+                headers={"selector": "colour = ("},
+                receipt_timeout=3,
+            )
+        assert not client._active_subscriptions.get_all()
+        assert not client._active_subscriptions.pending_receipts
+        await force_reconnect(client)
+        healthy = await client.subscribe_with_manual_ack(destination, handle_message, ack="auto", receipt_timeout=3)
+        try:
+            payload = str(uuid4()).encode()
+            await client.send(payload, destination)
+            assert await asyncio.wait_for(received, timeout=3) == payload
+            assert len(error_frames) == 1
+        finally:
+            await healthy.unsubscribe()
 
 
 @pytest.mark.anyio

--- a/packages/stompman/test_stompman/test_subscription_confirmation.py
+++ b/packages/stompman/test_stompman/test_subscription_confirmation.py
@@ -220,6 +220,51 @@ async def test_resubscription_failure_notifies_owner_and_cleans_up(
     assert not client._active_subscriptions.pending_receipts
 
 
+async def test_receipts_are_processed_while_later_subscription_replay_is_blocked(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    failures: list[stompman.SubscriptionError] = []
+    subscriptions: list[stompman.ManualAckSubscription] = []
+    for destination, timeout in (("first", 0.1), ("second", 1)):
+        task = asyncio.create_task(
+            client.subscribe_with_manual_ack(
+                destination, noop_message_handler, receipt_timeout=timeout, on_subscription_error=failures.append
+            )
+        )
+        connection, frame = await next_subscribe(outgoing)
+        receipt(incoming, connection, frame)
+        subscriptions.append(await task)
+
+    release_write = asyncio.Event()
+    write_blocked = asyncio.Event()
+    write_frame = BaseMockConnection.write_frame
+
+    async def delayed_write(connection: BaseMockConnection, frame: stompman.AnyClientFrame) -> None:
+        await write_frame(connection, frame)
+        if isinstance(frame, stompman.SubscribeFrame) and frame.headers["id"] == subscriptions[1].id:
+            write_blocked.set()
+            await release_write.wait()
+
+    monkeypatch.setattr(BaseMockConnection, "write_frame", delayed_write)
+    incoming[id(connection)].put_nowait(stompman.ConnectionLostError(reason="force replay"))
+    async with asyncio.TaskGroup() as tasks:
+        try:
+            for subscription in subscriptions:
+                restored_connection, restored = await next_subscribe(outgoing)
+                assert restored.headers["id"] == subscription.id
+                receipt(incoming, restored_connection, restored)
+            await asyncio.wait_for(write_blocked.wait(), timeout=1)
+            send = tasks.create_task(client.send(b"after replay", "test"))
+            await asyncio.sleep(0.2)
+            assert not failures
+            assert not client._active_subscriptions.pending_receipts
+            assert client._active_subscriptions.get_all() == subscriptions
+            assert not send.done()
+        finally:
+            release_write.set()
+    assert any(isinstance(frame, stompman.SendFrame) for frame in remaining_frames(outgoing))
+
+
 @pytest.mark.parametrize("timeout", [0, -1, float("nan"), float("inf")])
 async def test_invalid_receipt_timeout(client: stompman.Client, timeout: float) -> None:
     with pytest.raises(ValueError, match="finite positive"):

--- a/packages/stompman/test_stompman/test_subscription_confirmation.py
+++ b/packages/stompman/test_stompman/test_subscription_confirmation.py
@@ -10,7 +10,7 @@ from stompman.connection import AbstractConnection
 from test_stompman.conftest import BaseMockConnection, EnrichedClient, noop_message_handler
 
 pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
-Incoming = dict[AbstractConnection, asyncio.Queue[stompman.AnyServerFrame | stompman.ConnectionLostError]]
+Incoming = dict[int, asyncio.Queue[stompman.AnyServerFrame | stompman.ConnectionLostError]]
 Outgoing = asyncio.Queue[tuple[AbstractConnection, stompman.AnyClientFrame]]
 
 
@@ -31,7 +31,7 @@ async def client(
     async def write_frame(  # ruff: ignore[unused-async]
         connection: AbstractConnection, frame: stompman.AnyClientFrame
     ) -> None:
-        queue = incoming.setdefault(connection, asyncio.Queue())
+        queue = incoming.setdefault(id(connection), asyncio.Queue())
         outgoing.put_nowait((connection, frame))
         if isinstance(frame, stompman.ConnectFrame):
             queue.put_nowait(stompman.ConnectedFrame(headers={"version": "1.2", "heart-beat": "1000,1000"}))
@@ -39,7 +39,7 @@ async def client(
             queue.put_nowait(stompman.ReceiptFrame(headers={"receipt-id": frame.headers["receipt"]}))
 
     async def read_frames(connection: AbstractConnection) -> AsyncGenerator[stompman.AnyServerFrame, None]:
-        queue = incoming.setdefault(connection, asyncio.Queue())
+        queue = incoming.setdefault(id(connection), asyncio.Queue())
         while True:
             frame = await queue.get()
             if isinstance(frame, stompman.ConnectionLostError):
@@ -49,7 +49,10 @@ async def client(
     monkeypatch.setattr(BaseMockConnection, "write_frame", write_frame)
     monkeypatch.setattr(BaseMockConnection, "read_frames", read_frames)
     async with EnrichedClient(
-        connection_class=BaseMockConnection, connect_retry_interval=0, on_error_frame=mock.Mock()
+        connection_class=BaseMockConnection,
+        connect_retry_interval=0,
+        max_concurrent_handlers=1,
+        on_error_frame=mock.Mock(),
     ) as instance:
         try:
             yield instance
@@ -67,7 +70,7 @@ async def next_subscribe(outgoing: Outgoing) -> tuple[AbstractConnection, stompm
 
 
 def receipt(incoming: Incoming, connection: AbstractConnection, frame: stompman.SubscribeFrame) -> None:
-    incoming[connection].put_nowait(stompman.ReceiptFrame(headers={"receipt-id": frame.headers["receipt"]}))
+    incoming[id(connection)].put_nowait(stompman.ReceiptFrame(headers={"receipt-id": frame.headers["receipt"]}))
 
 
 def remaining_frames(outgoing: Outgoing) -> list[stompman.AnyClientFrame]:
@@ -91,8 +94,8 @@ async def test_subscribe_waits_for_matching_receipt(
     async with asyncio.TaskGroup() as tasks:
         task = tasks.create_task(subscribe)
         connection, frame = await next_subscribe(outgoing)
-        incoming[connection].put_nowait(stompman.ReceiptFrame(headers={"receipt-id": "unrelated"}))
-        incoming[connection].put_nowait(
+        incoming[id(connection)].put_nowait(stompman.ReceiptFrame(headers={"receipt-id": "unrelated"}))
+        incoming[id(connection)].put_nowait(
             stompman.ErrorFrame(headers={"message": "unrelated", "receipt-id": "unrelated"})
         )
         await asyncio.sleep(0)
@@ -123,14 +126,14 @@ async def test_rejected_subscription_is_removed_before_callback_and_not_replayed
         )
     )
     connection, frame = await next_subscribe(outgoing)
-    incoming[connection].put_nowait(
+    incoming[id(connection)].put_nowait(
         stompman.ErrorFrame(headers={"message": "subscription rejected", "receipt-id": frame.headers["receipt"]})
     )
     with pytest.raises(stompman.SubscriptionError, match="rejected"):
         await task
     assert len(failures) == 1
     assert not client._active_subscriptions.pending_receipts
-    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="peer closed after ERROR"))
+    incoming[id(connection)].put_nowait(stompman.ConnectionLostError(reason="peer closed after ERROR"))
     await asyncio.sleep(0)
     await client.send(b"still usable", "test")
     assert all(not isinstance(frame, stompman.SubscribeFrame) for frame in remaining_frames(outgoing))
@@ -159,7 +162,7 @@ async def test_connection_loss_fails_unconfirmed_subscription(
 ) -> None:
     task = asyncio.create_task(client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=1))
     connection, _ = await next_subscribe(outgoing)
-    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="connection lost before receipt"))
+    incoming[id(connection)].put_nowait(stompman.ConnectionLostError(reason="connection lost before receipt"))
     with pytest.raises(stompman.SubscriptionError, match="connection_lost"):
         await task
     assert not client._active_subscriptions.get_all()
@@ -179,11 +182,11 @@ async def test_concurrent_subscription_rejection_does_not_remove_confirmed_subsc
     error_headers: stompman.frames.ErrorHeaders = {"message": "rejected"}
     if correlated:
         error_headers["receipt-id"] = rejected.headers["receipt"]
-    incoming[connection].put_nowait(stompman.ErrorFrame(headers=error_headers))
+    incoming[id(connection)].put_nowait(stompman.ErrorFrame(headers=error_headers))
     with pytest.raises(stompman.SubscriptionError, match="rejected"):
         await failed
     assert client._active_subscriptions.get_all() == [healthy]
-    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="peer closed"))
+    incoming[id(connection)].put_nowait(stompman.ConnectionLostError(reason="peer closed"))
     restored_connection, restored = await next_subscribe(outgoing)
     assert restored.headers["id"] == healthy.id
     assert restored.headers["receipt"] != accepted.headers["receipt"]
@@ -205,10 +208,10 @@ async def test_resubscription_failure_notifies_owner_and_cleans_up(
     connection, initial = await next_subscribe(outgoing)
     receipt(incoming, connection, initial)
     await task
-    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="force restore"))
+    incoming[id(connection)].put_nowait(stompman.ConnectionLostError(reason="force restore"))
     restored_connection, restored = await next_subscribe(outgoing)
     if reject:
-        incoming[restored_connection].put_nowait(
+        incoming[id(restored_connection)].put_nowait(
             stompman.ErrorFrame(headers={"message": "rejected", "receipt-id": restored.headers["receipt"]})
         )
     error = await asyncio.wait_for(failure, timeout=1)
@@ -224,8 +227,72 @@ async def test_invalid_receipt_timeout(client: stompman.Client, timeout: float) 
     assert not client._active_subscriptions.get_all()
 
 
-async def test_cancellation_after_receipt_during_write_cleans_up(
-    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("start_confirmation_early", [True, False])
+async def test_receipts_are_processed_when_handler_capacity_is_exhausted(
+    client: stompman.Client,
+    incoming: Incoming,
+    outgoing: Outgoing,
+    *,
+    start_confirmation_early: bool,
+) -> None:
+    start_confirmation = asyncio.Event()
+    finished = asyncio.Event()
+    failures: list[stompman.SubscriptionError] = []
+    active_handlers = 0
+    maximum_handlers = 0
+
+    async def handler(frame: stompman.AckableMessageFrame) -> None:
+        nonlocal active_handlers, maximum_handlers
+        active_handlers += 1
+        maximum_handlers = max(maximum_handlers, active_handlers)
+        try:
+            if frame.body == b"first":
+                await start_confirmation.wait()
+                subscription = await client.subscribe_with_manual_ack(
+                    "responses", noop_message_handler, receipt_timeout=1, on_subscription_error=failures.append
+                )
+                await subscription.unsubscribe()
+            else:
+                finished.set()
+        finally:
+            active_handlers -= 1
+
+    source = await client.subscribe_with_manual_ack("source", handler, ack="auto")
+    connection, source_frame = await next_subscribe(outgoing)
+    incoming[id(connection)].put_nowait(
+        stompman.MessageFrame(
+            headers={"subscription": source_frame.headers["id"], "destination": "source", "message-id": "1"},
+            body=b"first",
+        )
+    )
+    if start_confirmation_early:
+        start_confirmation.set()
+        response_connection, response_frame = await next_subscribe(outgoing)
+    incoming[id(connection)].put_nowait(
+        stompman.MessageFrame(
+            headers={"subscription": source_frame.headers["id"], "destination": "source", "message-id": "2"},
+            body=b"second",
+        )
+    )
+    if not start_confirmation_early:
+        await asyncio.sleep(0)
+        start_confirmation.set()
+        response_connection, response_frame = await next_subscribe(outgoing)
+    receipt(incoming, response_connection, response_frame)
+    await asyncio.wait_for(finished.wait(), timeout=2)
+    assert failures == []
+    assert maximum_handlers == 1
+    await source.unsubscribe()
+
+
+@pytest.mark.parametrize("cancel", [True, False])
+async def test_failure_after_receipt_during_write_cleans_up(
+    client: stompman.Client,
+    incoming: Incoming,
+    outgoing: Outgoing,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cancel: bool,
 ) -> None:
     write_frame = BaseMockConnection.write_frame
     blocked = asyncio.Event()
@@ -236,12 +303,16 @@ async def test_cancellation_after_receipt_during_write_cleans_up(
             await blocked.wait()
 
     monkeypatch.setattr(BaseMockConnection, "write_frame", blocked_write)
-    task = asyncio.create_task(client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=1))
+    task = asyncio.create_task(client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=0.05))
     connection, frame = await next_subscribe(outgoing)
     receipt(incoming, connection, frame)
     await asyncio.sleep(0)
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    if cancel:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    else:
+        with pytest.raises(stompman.SubscriptionError, match="timeout"):
+            await task
     assert not client._active_subscriptions.get_all()
     assert not client._active_subscriptions.pending_receipts

--- a/packages/stompman/test_stompman/test_subscription_confirmation.py
+++ b/packages/stompman/test_stompman/test_subscription_confirmation.py
@@ -278,6 +278,89 @@ async def test_receipts_are_processed_while_later_subscription_replay_is_blocked
     assert any(isinstance(frame, stompman.SendFrame) for frame in remaining_frames(outgoing))
 
 
+@pytest.mark.parametrize("connection_lost", [True, False])
+async def test_failed_replay_after_receipt_notifies_owner(
+    client: stompman.Client,
+    incoming: Incoming,
+    outgoing: Outgoing,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    connection_lost: bool,
+) -> None:
+    failures: list[stompman.SubscriptionError] = []
+    failed = asyncio.Event()
+
+    def on_failure(error: stompman.SubscriptionError) -> None:
+        failures.append(error)
+        failed.set()
+
+    task = asyncio.create_task(
+        client.subscribe_with_manual_ack(
+            "test", noop_message_handler, receipt_timeout=0.05, on_subscription_error=on_failure
+        )
+    )
+    connection, initial = await next_subscribe(outgoing)
+    receipt(incoming, connection, initial)
+    await task
+    write_frame = BaseMockConnection.write_frame
+
+    async def blocked_write(connection: BaseMockConnection, frame: stompman.AnyClientFrame) -> None:
+        await write_frame(connection, frame)
+        if isinstance(frame, stompman.SubscribeFrame):
+            await asyncio.Future()
+
+    monkeypatch.setattr(BaseMockConnection, "write_frame", blocked_write)
+    incoming[id(connection)].put_nowait(stompman.ConnectionLostError(reason="force replay"))
+    restored_connection, restored = await next_subscribe(outgoing)
+    receipt(incoming, restored_connection, restored)
+    if connection_lost:
+        incoming[id(restored_connection)].put_nowait(stompman.ConnectionLostError(reason="lost while draining"))
+    await asyncio.wait_for(failed.wait(), timeout=1)
+    assert [error.reason for error in failures] == ["connection_lost" if connection_lost else "timeout"]
+    assert not client._active_subscriptions.get_all()
+    assert not client._active_subscriptions.pending_receipts
+    await client.send(b"still usable", "test")
+    assert all(not isinstance(frame, stompman.SubscribeFrame) for frame in remaining_frames(outgoing))
+
+
+async def test_transaction_finalization_does_not_overtake_replay(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task = asyncio.create_task(client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=1))
+    connection, initial = await next_subscribe(outgoing)
+    receipt(incoming, connection, initial)
+    await task
+    write_frame = BaseMockConnection.write_frame
+    release_write = asyncio.Event()
+
+    async def blocked_write(connection: BaseMockConnection, frame: stompman.AnyClientFrame) -> None:
+        await write_frame(connection, frame)
+        if isinstance(frame, stompman.SubscribeFrame):
+            await release_write.wait()
+
+    monkeypatch.setattr(BaseMockConnection, "write_frame", blocked_write)
+    async with asyncio.TaskGroup() as tasks:
+        try:
+            async with client.begin() as transaction:
+                await transaction.send(b"buffered message", "test")
+                remaining_frames(outgoing)
+                incoming[id(connection)].put_nowait(stompman.ConnectionLostError(reason="force replay"))
+                restored_connection, restored = await next_subscribe(outgoing)
+                receipt(incoming, restored_connection, restored)
+            assert not any(isinstance(frame, stompman.CommitFrame) for frame in remaining_frames(outgoing))
+            assert transaction in client._active_transactions
+            tasks.create_task(client.send(b"after replay", "test"))
+        finally:
+            release_write.set()
+    replayed = remaining_frames(outgoing)
+    assert [frame.body for frame in replayed if isinstance(frame, stompman.SendFrame)] == [
+        b"buffered message",
+        b"after replay",
+    ]
+    assert len([frame for frame in replayed if isinstance(frame, stompman.CommitFrame)]) == 1
+    assert not client._active_transactions
+
+
 @pytest.mark.parametrize("timeout", [0, -1, float("nan"), float("inf")])
 async def test_invalid_receipt_timeout(client: stompman.Client, timeout: float) -> None:
     with pytest.raises(ValueError, match="finite positive"):

--- a/packages/stompman/test_stompman/test_subscription_confirmation.py
+++ b/packages/stompman/test_stompman/test_subscription_confirmation.py
@@ -220,8 +220,14 @@ async def test_resubscription_failure_notifies_owner_and_cleans_up(
     assert not client._active_subscriptions.pending_receipts
 
 
+@pytest.mark.parametrize("cancel_send", [True, False])
 async def test_receipts_are_processed_while_later_subscription_replay_is_blocked(
-    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, monkeypatch: pytest.MonkeyPatch
+    client: stompman.Client,
+    incoming: Incoming,
+    outgoing: Outgoing,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cancel_send: bool,
 ) -> None:
     failures: list[stompman.SubscriptionError] = []
     subscriptions: list[stompman.ManualAckSubscription] = []
@@ -260,6 +266,13 @@ async def test_receipts_are_processed_while_later_subscription_replay_is_blocked
             assert not client._active_subscriptions.pending_receipts
             assert client._active_subscriptions.get_all() == subscriptions
             assert not send.done()
+            if cancel_send:
+                send.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await send
+                send = tasks.create_task(client.send(b"after cancelled send", "test"))
+                await asyncio.sleep(0)
+                assert not send.done()
         finally:
             release_write.set()
     assert any(isinstance(frame, stompman.SendFrame) for frame in remaining_frames(outgoing))

--- a/packages/stompman/test_stompman/test_subscription_confirmation.py
+++ b/packages/stompman/test_stompman/test_subscription_confirmation.py
@@ -1,0 +1,247 @@
+import asyncio
+from collections.abc import AsyncGenerator, Coroutine
+from typing import Any
+from unittest import mock
+
+import pytest
+import stompman
+from stompman.connection import AbstractConnection
+
+from test_stompman.conftest import BaseMockConnection, EnrichedClient, noop_message_handler
+
+pytestmark = [pytest.mark.anyio, pytest.mark.timeout(10)]
+Incoming = dict[AbstractConnection, asyncio.Queue[stompman.AnyServerFrame | stompman.ConnectionLostError]]
+Outgoing = asyncio.Queue[tuple[AbstractConnection, stompman.AnyClientFrame]]
+
+
+@pytest.fixture
+def incoming() -> Incoming:
+    return {}
+
+
+@pytest.fixture
+def outgoing() -> Outgoing:
+    return asyncio.Queue()
+
+
+@pytest.fixture
+async def client(
+    monkeypatch: pytest.MonkeyPatch, incoming: Incoming, outgoing: Outgoing
+) -> AsyncGenerator[stompman.Client, None]:
+    async def write_frame(  # ruff: ignore[unused-async]
+        connection: AbstractConnection, frame: stompman.AnyClientFrame
+    ) -> None:
+        queue = incoming.setdefault(connection, asyncio.Queue())
+        outgoing.put_nowait((connection, frame))
+        if isinstance(frame, stompman.ConnectFrame):
+            queue.put_nowait(stompman.ConnectedFrame(headers={"version": "1.2", "heart-beat": "1000,1000"}))
+        elif isinstance(frame, stompman.DisconnectFrame):
+            queue.put_nowait(stompman.ReceiptFrame(headers={"receipt-id": frame.headers["receipt"]}))
+
+    async def read_frames(connection: AbstractConnection) -> AsyncGenerator[stompman.AnyServerFrame, None]:
+        queue = incoming.setdefault(connection, asyncio.Queue())
+        while True:
+            frame = await queue.get()
+            if isinstance(frame, stompman.ConnectionLostError):
+                raise frame
+            yield frame
+
+    monkeypatch.setattr(BaseMockConnection, "write_frame", write_frame)
+    monkeypatch.setattr(BaseMockConnection, "read_frames", read_frames)
+    async with EnrichedClient(
+        connection_class=BaseMockConnection, connect_retry_interval=0, on_error_frame=mock.Mock()
+    ) as instance:
+        try:
+            yield instance
+        finally:
+            for subscription in instance._active_subscriptions.get_all():
+                await subscription.unsubscribe()
+
+
+async def next_subscribe(outgoing: Outgoing) -> tuple[AbstractConnection, stompman.SubscribeFrame]:
+    async with asyncio.timeout(1):
+        while True:
+            connection, frame = await outgoing.get()
+            if isinstance(frame, stompman.SubscribeFrame):
+                return connection, frame
+
+
+def receipt(incoming: Incoming, connection: AbstractConnection, frame: stompman.SubscribeFrame) -> None:
+    incoming[connection].put_nowait(stompman.ReceiptFrame(headers={"receipt-id": frame.headers["receipt"]}))
+
+
+def remaining_frames(outgoing: Outgoing) -> list[stompman.AnyClientFrame]:
+    frames: list[stompman.AnyClientFrame] = []
+    while not outgoing.empty():
+        frames.append(outgoing.get_nowait()[1])
+    return frames
+
+
+@pytest.mark.parametrize("manual_ack", [True, False])
+async def test_subscribe_waits_for_matching_receipt(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, *, manual_ack: bool
+) -> None:
+    subscribe: Coroutine[Any, Any, stompman.ManualAckSubscription | stompman.AutoAckSubscription]
+    if manual_ack:
+        subscribe = client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=1)
+    else:
+        subscribe = client.subscribe(
+            "test", noop_message_handler, on_suppressed_exception=mock.Mock(), receipt_timeout=1
+        )
+    async with asyncio.TaskGroup() as tasks:
+        task = tasks.create_task(subscribe)
+        connection, frame = await next_subscribe(outgoing)
+        incoming[connection].put_nowait(stompman.ReceiptFrame(headers={"receipt-id": "unrelated"}))
+        incoming[connection].put_nowait(
+            stompman.ErrorFrame(headers={"message": "unrelated", "receipt-id": "unrelated"})
+        )
+        await asyncio.sleep(0)
+        assert not task.done()
+        receipt(incoming, connection, frame)
+    subscription = task.result()
+    assert subscription.id == frame.headers["id"]
+    assert not client._active_subscriptions.pending_receipts
+    await subscription.unsubscribe()
+
+
+@pytest.mark.parametrize("callback_raises", [True, False])
+async def test_rejected_subscription_is_removed_before_callback_and_not_replayed(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, *, callback_raises: bool
+) -> None:
+    failures: list[stompman.SubscriptionError] = []
+
+    def on_failure(error: stompman.SubscriptionError) -> None:
+        assert not client._active_subscriptions.contains_by_id(error.subscription_id)
+        failures.append(error)
+        if callback_raises:
+            msg = "broken callback"
+            raise RuntimeError(msg)
+
+    task = asyncio.create_task(
+        client.subscribe_with_manual_ack(
+            "test", noop_message_handler, receipt_timeout=1, on_subscription_error=on_failure
+        )
+    )
+    connection, frame = await next_subscribe(outgoing)
+    incoming[connection].put_nowait(
+        stompman.ErrorFrame(headers={"message": "subscription rejected", "receipt-id": frame.headers["receipt"]})
+    )
+    with pytest.raises(stompman.SubscriptionError, match="rejected"):
+        await task
+    assert len(failures) == 1
+    assert not client._active_subscriptions.pending_receipts
+    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="peer closed after ERROR"))
+    await asyncio.sleep(0)
+    await client.send(b"still usable", "test")
+    assert all(not isinstance(frame, stompman.SubscribeFrame) for frame in remaining_frames(outgoing))
+
+
+@pytest.mark.parametrize("cancel", [True, False])
+async def test_confirmation_timeout_and_cancellation_cleanup(
+    client: stompman.Client, outgoing: Outgoing, *, cancel: bool
+) -> None:
+    task = asyncio.create_task(client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=0.05))
+    await next_subscribe(outgoing)
+    if cancel:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    else:
+        with pytest.raises(stompman.SubscriptionError, match="timeout"):
+            await task
+    assert not client._active_subscriptions.get_all()
+    assert not client._active_subscriptions.pending_receipts
+    assert any(isinstance(frame, stompman.UnsubscribeFrame) for frame in remaining_frames(outgoing))
+
+
+async def test_connection_loss_fails_unconfirmed_subscription(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing
+) -> None:
+    task = asyncio.create_task(client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=1))
+    connection, _ = await next_subscribe(outgoing)
+    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="connection lost before receipt"))
+    with pytest.raises(stompman.SubscriptionError, match="connection_lost"):
+        await task
+    assert not client._active_subscriptions.get_all()
+    assert not client._active_subscriptions.pending_receipts
+
+
+@pytest.mark.parametrize("correlated", [True, False])
+async def test_concurrent_subscription_rejection_does_not_remove_confirmed_subscription(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, *, correlated: bool
+) -> None:
+    first = asyncio.create_task(client.subscribe_with_manual_ack("good", noop_message_handler, receipt_timeout=1))
+    connection, accepted = await next_subscribe(outgoing)
+    receipt(incoming, connection, accepted)
+    healthy = await first
+    failed = asyncio.create_task(client.subscribe_with_manual_ack("bad", noop_message_handler, receipt_timeout=1))
+    connection, rejected = await next_subscribe(outgoing)
+    error_headers: stompman.frames.ErrorHeaders = {"message": "rejected"}
+    if correlated:
+        error_headers["receipt-id"] = rejected.headers["receipt"]
+    incoming[connection].put_nowait(stompman.ErrorFrame(headers=error_headers))
+    with pytest.raises(stompman.SubscriptionError, match="rejected"):
+        await failed
+    assert client._active_subscriptions.get_all() == [healthy]
+    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="peer closed"))
+    restored_connection, restored = await next_subscribe(outgoing)
+    assert restored.headers["id"] == healthy.id
+    assert restored.headers["receipt"] != accepted.headers["receipt"]
+    receipt(incoming, restored_connection, restored)
+    await asyncio.sleep(0)
+    await healthy.unsubscribe()
+
+
+@pytest.mark.parametrize("reject", [True, False])
+async def test_resubscription_failure_notifies_owner_and_cleans_up(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, *, reject: bool
+) -> None:
+    failure = asyncio.get_running_loop().create_future()
+    task = asyncio.create_task(
+        client.subscribe_with_manual_ack(
+            "test", noop_message_handler, receipt_timeout=0.05, on_subscription_error=failure.set_result
+        )
+    )
+    connection, initial = await next_subscribe(outgoing)
+    receipt(incoming, connection, initial)
+    await task
+    incoming[connection].put_nowait(stompman.ConnectionLostError(reason="force restore"))
+    restored_connection, restored = await next_subscribe(outgoing)
+    if reject:
+        incoming[restored_connection].put_nowait(
+            stompman.ErrorFrame(headers={"message": "rejected", "receipt-id": restored.headers["receipt"]})
+        )
+    error = await asyncio.wait_for(failure, timeout=1)
+    assert error.reason == ("rejected" if reject else "timeout")
+    assert not client._active_subscriptions.get_all()
+    assert not client._active_subscriptions.pending_receipts
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("nan"), float("inf")])
+async def test_invalid_receipt_timeout(client: stompman.Client, timeout: float) -> None:
+    with pytest.raises(ValueError, match="finite positive"):
+        await client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=timeout)
+    assert not client._active_subscriptions.get_all()
+
+
+async def test_cancellation_after_receipt_during_write_cleans_up(
+    client: stompman.Client, incoming: Incoming, outgoing: Outgoing, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_frame = BaseMockConnection.write_frame
+    blocked = asyncio.Event()
+
+    async def blocked_write(connection: BaseMockConnection, frame: stompman.AnyClientFrame) -> None:
+        await write_frame(connection, frame)
+        if isinstance(frame, stompman.SubscribeFrame):
+            await blocked.wait()
+
+    monkeypatch.setattr(BaseMockConnection, "write_frame", blocked_write)
+    task = asyncio.create_task(client.subscribe_with_manual_ack("test", noop_message_handler, receipt_timeout=1))
+    connection, frame = await next_subscribe(outgoing)
+    receipt(incoming, connection, frame)
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not client._active_subscriptions.get_all()
+    assert not client._active_subscriptions.pending_receipts


### PR DESCRIPTION
Agent:

## Problem

A successful socket write does not mean a broker accepted a subscription.
Currently, subscription errors only reach the client-wide error callback,
while the rejected subscription stays eligible for automatic replay. A broker
that sends ERROR and immediately closes the connection can therefore cause
repeated reconnect/resubscribe attempts.

## Proposed API

```python
subscription = await client.subscribe_with_manual_ack(
    "responses",
    handle_response,
    receipt_timeout=3.0,
    on_subscription_error=handle_subscription_error,
)
# Publish the corresponding request only after subscription confirmation.
```

Both `subscribe()` and `subscribe_with_manual_ack()` accept the new optional
arguments. Their return types are unchanged. `receipt_timeout=None` retains
the existing write-only behavior.

## Implementation

- Correlate standard STOMP RECEIPT and ERROR frames with pending subscriptions,
  using fresh receipt IDs and connection epochs.
- Remove a rejected subscription before waking its waiter or invoking its
  error callback. Raise a typed `SubscriptionError` for initial failures;
  the per-subscription callback also reports failed resubscription.
- Keep the frame reader free to receive confirmations, including during
  connection replay and saturated handler capacity. Track and clean up
  background replay and confirmation tasks.
- Preserve subscription-before-send and transaction-finalization ordering.
  A cancelled send does not cancel shared replay; startup without replay keeps
  its existing fast path.
- Clean up on timeout, cancellation, unsubscribe, and connection loss.
- Fail pending confirmations conservatively for an uncorrelated ERROR, without
  evicting already confirmed subscriptions.
- Apply `connect_retry_interval` to successful-but-short-lived connections too.

This uses the [STOMP 1.2 receipt contract](https://stomp.github.io/stomp-specification-1.2.html#RECEIPT).
ERROR correlation is a SHOULD in the protocol, so missing receipt IDs are
handled explicitly. No broker-specific error-string parsing or client override
is introduced.

## Verification

- Local Ruff checks, strict mypy, and package build: passed.
- [CI on `67cb1bc`](https://github.com/community-of-python/stompman/actions/runs/33921348307):
  lint and typing passed; 392 tests passed and 1 skipped on each of Python
  3.11, 3.12, 3.13, and 3.14.
- Added protocol-boundary tests for receipts, rejection, callback isolation,
  concurrency, timeout/cancellation, reconnect failures, and retry spacing.
- Added real-broker CI checks for rejection/recovery on Artemis and ActiveMQ
  Classic, plus receipt-enabled reconnect coverage.
- The replay-starvation regression was first reproduced in
  [CI before the fix](https://github.com/community-of-python/stompman/actions/runs/33919570823).
- Fresh independent review of `67cb1bc` against `3491078`: no material findings.

## Compatibility

Subscription return types and default write-only behavior are unchanged.
This change targets `stompman`; it does not require a `faststream-stomp` release.
